### PR TITLE
Feat : OW-22 GlobalException 구축

### DIFF
--- a/back/src/main/java/com/ogjg/back/common/controller/ExceptionControllerAdvice.java
+++ b/back/src/main/java/com/ogjg/back/common/controller/ExceptionControllerAdvice.java
@@ -25,7 +25,7 @@ public class ExceptionControllerAdvice {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseBody
-    public ApiResponse<?> customValidationHandler(
+    public ApiResponse<?> validationHandler(
             HttpServletResponse response, MethodArgumentNotValidException e
     ) {
         response.setStatus(ErrorCode.INVALID_FORMAT.getStatusCode().value());

--- a/back/src/main/java/com/ogjg/back/common/controller/ExceptionControllerAdvice.java
+++ b/back/src/main/java/com/ogjg/back/common/controller/ExceptionControllerAdvice.java
@@ -1,0 +1,23 @@
+package com.ogjg.back.common.controller;
+
+import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.response.ApiResponse;
+import com.ogjg.back.common.response.ErrorResponse;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@ControllerAdvice
+public class ExceptionControllerAdvice {
+
+    @ExceptionHandler(CustomException.class)
+    @ResponseBody
+    public ApiResponse<?> customExceptionHandler(
+            HttpServletResponse response, CustomException e
+    ){
+        response.setStatus(e.getErrorCode().getStatusCode().value());
+        return new ErrorResponse(e.getErrorCode(),e.getErrorData());
+    }
+
+}

--- a/back/src/main/java/com/ogjg/back/common/controller/ExceptionControllerAdvice.java
+++ b/back/src/main/java/com/ogjg/back/common/controller/ExceptionControllerAdvice.java
@@ -1,9 +1,12 @@
 package com.ogjg.back.common.controller;
 
 import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.response.ApiResponse;
 import com.ogjg.back.common.response.ErrorResponse;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -15,9 +18,25 @@ public class ExceptionControllerAdvice {
     @ResponseBody
     public ApiResponse<?> customExceptionHandler(
             HttpServletResponse response, CustomException e
-    ){
+    ) {
         response.setStatus(e.getErrorCode().getStatusCode().value());
-        return new ErrorResponse(e.getErrorCode(),e.getErrorData());
+        return new ErrorResponse(e.getErrorCode(), e.getErrorData());
     }
 
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseBody
+    public ApiResponse<?> customValidationHandler(
+            HttpServletResponse response, MethodArgumentNotValidException e
+    ) {
+        response.setStatus(ErrorCode.INVALID_FORMAT.getStatusCode().value());
+        String errorMessage = validationErrorMessage(e.getBindingResult().getFieldError());
+        return new ErrorResponse(ErrorCode.INVALID_FORMAT.changeMessage(errorMessage));
+    }
+
+    private String validationErrorMessage(FieldError fieldError) {
+        if (fieldError != null) {
+            return fieldError.getDefaultMessage();
+        }
+        return ErrorCode.INVALID_FORMAT.getMessage();
+    }
 }

--- a/back/src/main/java/com/ogjg/back/common/exception/CustomException.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/CustomException.java
@@ -3,7 +3,7 @@ package com.ogjg.back.common.exception;
 import lombok.Getter;
 
 @Getter
-public abstract class CustomException extends RuntimeException{
+public abstract class CustomException extends RuntimeException {
 
     private final ErrorCode errorCode;
     private ErrorData errorData;

--- a/back/src/main/java/com/ogjg/back/common/exception/CustomException.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/CustomException.java
@@ -1,0 +1,21 @@
+package com.ogjg.back.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class CustomException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+    private ErrorData errorData;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, ErrorData errorData) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+        this.errorData = errorData;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -7,8 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-    SUCCESS(HttpStatus.OK,"200","OK"),
-    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "코드는내맘대로에러","회원를 찾을 수 없습니다");
+    SUCCESS(HttpStatus.OK, "200", "OK"),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "404", "회원를 찾을 수 없습니다"),
+    INVALID_FORMAT(HttpStatus.BAD_REQUEST, "400", "데이터를 검증 실패");
 
     @JsonIgnore
     private final HttpStatus statusCode;
@@ -21,7 +22,7 @@ public enum ErrorCode {
         this.message = message;
     }
 
-    ErrorCode changeMessage(String message){
+    public ErrorCode changeMessage(String message) {
         this.message = message;
         return this;
     }

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -1,0 +1,28 @@
+package com.ogjg.back.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    SUCCESS(HttpStatus.OK,"200","OK"),
+    NOT_FOUND_USER(HttpStatus.NOT_FOUND, "코드는내맘대로에러","회원를 찾을 수 없습니다");
+
+    @JsonIgnore
+    private final HttpStatus statusCode;
+    private final String code;
+    private String message;
+
+    ErrorCode(HttpStatus statusCode, String code, String message) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+
+    ErrorCode changeMessage(String message){
+        this.message = message;
+        return this;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorData.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorData.java
@@ -1,0 +1,4 @@
+package com.ogjg.back.common.exception;
+
+public interface ErrorData {
+}

--- a/back/src/main/java/com/ogjg/back/common/response/ApiResponse.java
+++ b/back/src/main/java/com/ogjg/back/common/response/ApiResponse.java
@@ -1,0 +1,22 @@
+package com.ogjg.back.common.response;
+
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.response.dto.Status;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T>{
+
+    private Status status;
+
+    private T data;
+
+    public ApiResponse(ErrorCode errorCode) {
+        this.status = new Status(errorCode);
+    }
+
+    public ApiResponse(ErrorCode errorCode, T data) {
+        this.status = new Status(errorCode);
+        this.data = data;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/common/response/ApiResponse.java
+++ b/back/src/main/java/com/ogjg/back/common/response/ApiResponse.java
@@ -5,7 +5,7 @@ import com.ogjg.back.common.response.dto.Status;
 import lombok.Getter;
 
 @Getter
-public class ApiResponse<T>{
+public class ApiResponse<T> {
 
     private Status status;
 

--- a/back/src/main/java/com/ogjg/back/common/response/ErrorResponse.java
+++ b/back/src/main/java/com/ogjg/back/common/response/ErrorResponse.java
@@ -3,7 +3,7 @@ package com.ogjg.back.common.response;
 import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.exception.ErrorData;
 
-public class ErrorResponse extends ApiResponse<Object> {
+public class ErrorResponse extends ApiResponse<ErrorData> {
 
     public ErrorResponse(ErrorCode errorCode) {
         super(errorCode);
@@ -12,4 +12,5 @@ public class ErrorResponse extends ApiResponse<Object> {
     public ErrorResponse(ErrorCode errorCode, ErrorData errorData) {
         super(errorCode, errorData);
     }
+
 }

--- a/back/src/main/java/com/ogjg/back/common/response/ErrorResponse.java
+++ b/back/src/main/java/com/ogjg/back/common/response/ErrorResponse.java
@@ -3,7 +3,7 @@ package com.ogjg.back.common.response;
 import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.exception.ErrorData;
 
-public class ErrorResponse extends ApiResponse{
+public class ErrorResponse extends ApiResponse<Object> {
 
     public ErrorResponse(ErrorCode errorCode) {
         super(errorCode);

--- a/back/src/main/java/com/ogjg/back/common/response/ErrorResponse.java
+++ b/back/src/main/java/com/ogjg/back/common/response/ErrorResponse.java
@@ -1,0 +1,15 @@
+package com.ogjg.back.common.response;
+
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorData;
+
+public class ErrorResponse extends ApiResponse{
+
+    public ErrorResponse(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ErrorResponse(ErrorCode errorCode, ErrorData errorData) {
+        super(errorCode, errorData);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/common/response/dto/Status.java
+++ b/back/src/main/java/com/ogjg/back/common/response/dto/Status.java
@@ -1,0 +1,19 @@
+package com.ogjg.back.common.response.dto;
+
+
+import com.ogjg.back.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+public class Status {
+    private String code;
+    private String message;
+
+    public Status(ErrorCode errorCode) {
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+}

--- a/back/src/main/java/com/ogjg/back/common/response/dto/Status.java
+++ b/back/src/main/java/com/ogjg/back/common/response/dto/Status.java
@@ -4,7 +4,6 @@ package com.ogjg.back.common.response.dto;
 import com.ogjg.back.common.exception.ErrorCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
 @NoArgsConstructor


### PR DESCRIPTION
ApiResponse : 모든 api 응답 모델에서 사용가능하게 Generic Type으로 정의
 - 정상 api 응답 : 
         반환타입 : ApiResponse 
         return Type : new ApiResponse<>(ErrorCode, 응답보내줄 responseDto);
 - Error 발생 : 
         반환타입 : ApiResponse 
         return Type : ErrorResponse(ErrorCode, ErrorData)

ErrorData : 
 - Error 대한 상세내용이 더 필요하다면 객체를 생성하고 ErrorData 상속받아 사용
 - ErrorResponse의 생성자 파라미터에 Generic Type을 사용하지 않고, ErrorData 인터페이스로 타입을 제한하는게 안정성이 높다고 판단했다.

ErrorCode : 
 - 어떠한 에러들이 있는지 Enum Type으로 정의 message를 변경하고자 한다면 ErrorCode.반환에러타입.changeMessage(바꿀내용)으로 메시지의 내용만 변경 가능

CustomException : 
 - 도메인에서 Exception에 대한 정의가 필요하다면 CustomException 상속받아 정의