### PR TITLE
Feat : OW-28 코드 편집 페이지 사이드 바 UI 

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,8 +8,11 @@
       "name": "instagram",
       "version": "0.0.0",
       "dependencies": {
+        "@monaco-editor/react": "^4.5.2",
         "@tanstack/react-query": "^4.33.0",
         "axios": "^1.4.0",
+        "rc-tooltip": "^6.0.1",
+        "rc-tree": "^5.7.10",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.10.1",
@@ -2428,6 +2431,30 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
       "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.3.3.tgz",
+      "integrity": "sha512-6KKF4CTzcJiS8BJwtxtfyYt9shBiEv32ateQ9T4UVogwn4HM/uPo9iJd2Dmbkpz8CM6Y0PDUpjnZzCwC+eYo2Q==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.5.2.tgz",
+      "integrity": "sha512-emcWu6vg1OpXPiYll4aPOaXe8bwYB4UaaNTwtArFLgMoNGBzRZb2Xn0Bra2HMIFM7QLgs7fCGunHO5LkfT2LBA==",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.3.3"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -2487,6 +2514,44 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@rc-component/portal": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rc-component/portal/-/portal-1.1.2.tgz",
+      "integrity": "sha512-6f813C0IsasTZms08kfA8kPAGxbbkYToa8ALaiDIGGECU4i9hj8Plgbx0sNJDrey3EtHO30hmdaxtT0138xZcg==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.0",
+        "classnames": "^2.3.2",
+        "rc-util": "^5.24.4"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/@rc-component/trigger": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/@rc-component/trigger/-/trigger-1.15.6.tgz",
+      "integrity": "sha512-Tl19KaGsShf4yzqxumsXVT4c7j0l20Dxe5hgP5S0HmxyhCg3oKen28ntGavRCIPW7cl7wgsGotntqcIokgDHzg==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@rc-component/portal": "^1.1.0",
+        "classnames": "^2.3.2",
+        "rc-align": "^4.0.0",
+        "rc-motion": "^2.0.0",
+        "rc-resize-observer": "^1.3.1",
+        "rc-util": "^5.33.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
       }
     },
     "node_modules/@remix-run/router": {
@@ -3171,6 +3236,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3366,6 +3436,11 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-align": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/dom-align/-/dom-align-1.12.4.tgz",
+      "integrity": "sha512-R8LUSEay/68zE5c8/3BDxiTEvgb4xZTF0RKmAHfiEVN3klfIpXfi2/QCoiWPccVQ0J/ZGdz9OjzL4uJEP/MRAw=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.480",
@@ -4454,6 +4529,12 @@
         "node": "*"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.43.0.tgz",
+      "integrity": "sha512-cnoqwQi/9fml2Szamv1XbSJieGJ1Dc8tENVMD26Kcfl7xGQWp7OBKMjlwKVGYFJ3/AXJjSOGvcqK7Ry/j9BM1Q==",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4814,6 +4895,115 @@
         }
       ]
     },
+    "node_modules/rc-align": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.15.tgz",
+      "integrity": "sha512-wqJtVH60pka/nOX7/IspElA8gjPNQKIx/ZqJ6heATCkXpe1Zg4cPVrMD2vC96wjsFFL8WsmhPbx9tdMo1qqlIA==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "dom-align": "^1.7.0",
+        "rc-util": "^5.26.0",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-motion": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.9.0.tgz",
+      "integrity": "sha512-XIU2+xLkdIr1/h6ohPZXyPBMvOmuyFZQ/T0xnawz+Rh+gh4FINcnZmMT5UTIj6hgI0VLDjTaPeRd+smJeSPqiQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.1",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.21.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-resize-observer": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/rc-resize-observer/-/rc-resize-observer-1.3.1.tgz",
+      "integrity": "sha512-iFUdt3NNhflbY3mwySv5CA1TC06zdJ+pfo0oc27xpf4PIOvfZwZGtD9Kz41wGYqC4SLio93RVAirSSpYlV/uYg==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.7",
+        "classnames": "^2.2.1",
+        "rc-util": "^5.27.0",
+        "resize-observer-polyfill": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-tooltip": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-6.0.1.tgz",
+      "integrity": "sha512-MdvPlsD1fDSxKp9+HjXrc/CxLmA/s11QYIh1R7aExxfodKP7CZA++DG1AjrW80F8IUdHYcR43HAm0Y2BYPelHA==",
+      "dependencies": {
+        "@babel/runtime": "^7.11.2",
+        "@rc-component/trigger": "^1.0.4",
+        "classnames": "^2.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-tree": {
+      "version": "5.7.10",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-5.7.10.tgz",
+      "integrity": "sha512-n4UkMQY3bzvJUNnbw6e3YI7sy2kE9c9vAYbSt94qAhcPKtMOThONNr1LIaFB/M5XeFYYrWVbvRVoT8k38eFuSQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.1",
+        "classnames": "2.x",
+        "rc-motion": "^2.0.1",
+        "rc-util": "^5.16.1",
+        "rc-virtual-list": "^3.5.1"
+      },
+      "engines": {
+        "node": ">=10.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
+    "node_modules/rc-util": {
+      "version": "5.37.0",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.37.0.tgz",
+      "integrity": "sha512-cPMV8DzaHI1KDaS7XPRXAf4J7mtBqjvjikLpQieaeOO7+cEbqY2j7Kso/T0R0OiEZTNcLS/8Zl9YrlXiO9UbjQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^16.12.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-virtual-list": {
+      "version": "3.10.7",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.10.7.tgz",
+      "integrity": "sha512-NZl8nsNV2kf0k9o4SHt6u/2kFBhE0SRTh71msUZkUB/rfNTBRKnhLXf8bD2jayT7TkprnbHBCPQbPqwJo2BSJw==",
+      "dependencies": {
+        "@babel/runtime": "^7.20.0",
+        "classnames": "^2.2.6",
+        "rc-resize-observer": "^1.0.0",
+        "rc-util": "^5.36.0"
+      },
+      "engines": {
+        "node": ">=8.x"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
+      }
+    },
     "node_modules/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -5000,6 +5190,11 @@
       "bin": {
         "jsesc": "bin/jsesc"
       }
+    },
+    "node_modules/resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
     },
     "node_modules/resolve": {
       "version": "1.22.2",
@@ -5288,6 +5483,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",

--- a/front/package.json
+++ b/front/package.json
@@ -10,8 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@monaco-editor/react": "^4.5.2",
     "@tanstack/react-query": "^4.33.0",
     "axios": "^1.4.0",
+    "rc-tooltip": "^6.0.1",
+    "rc-tree": "^5.7.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.10.1",

--- a/front/src/components/FileIcon.tsx
+++ b/front/src/components/FileIcon.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from "react";
+import { SiHtml5, SiCss3, SiJavascript, SiTypescript, SiJson } from "react-icons/si";
+import { FcFolder, FcOpenedFolder, FcPicture, FcFile } from "react-icons/fc";
+import { AiFillFileText } from "react-icons/ai";
+
+function getIconHelper() {
+  const cache = new Map<string, ReactNode>();
+
+  cache.set("js", <SiJavascript color="#fbcb38" />);
+  cache.set("jsx", <SiJavascript color="#fbcb38" />);
+  cache.set("ts", <SiTypescript color="#378baa" />);
+  cache.set("tsx", <SiTypescript color="#c84f12" />);
+  cache.set("css", <SiCss3 color="#c84f12" />);
+  cache.set("json", <SiJson color="#5656e6" />);
+  cache.set("html", <SiHtml5 color="#e04e2c" />);
+  cache.set("png", <FcPicture />);
+  cache.set("jpg", <FcPicture />);
+  cache.set("ico", <FcPicture />);
+  cache.set("txt", <AiFillFileText color="white" />);
+  cache.set("closedDirectory", <FcFolder />);
+  cache.set("openDirectory", <FcOpenedFolder />);
+
+  return function (extension: string): ReactNode {
+    if (cache.has(extension)) return cache.get(extension);
+    else return <FcFile />;
+  };
+}
+
+export const getIcon = getIconHelper();

--- a/front/src/components/Icon.tsx
+++ b/front/src/components/Icon.tsx
@@ -10,6 +10,7 @@ import * as Fa from "react-icons/fa";
 import * as Ri from "react-icons/ri";
 import * as Gr from "react-icons/gr";
 import * as Fi from "react-icons/fi";
+import "./Icons.css";
 const DEFAULT = 16;
 
 // 로그인
@@ -54,7 +55,9 @@ export const Back = ({ size = DEFAULT }) => <Bs.BsArrowLeftShort size={size} />;
 // 컨테이너 코드 편집
 export const FolderOpen = ({ size = DEFAULT }) => <Ai.AiFillFolderOpen size={size} />;
 export const FolderClose = ({ size = DEFAULT }) => <Bs.BsFolderMinus size={size} />;
-export const Refresh = ({ size = DEFAULT }) => <Gr.GrRefresh size={size} />;
+export const Refresh = ({ size = DEFAULT }) => (
+  <Gr.GrRefresh size={size} className="GrReresh" />
+);
 export const Save = ({ size = DEFAULT }) => <Bi.BiSave size={size} />;
 export const Chat = ({ size = DEFAULT }) => <Bs.BsChatLeftDots size={size} />;
 

--- a/front/src/components/Icons.css
+++ b/front/src/components/Icons.css
@@ -1,0 +1,3 @@
+.GrReresh path {
+    stroke: white;
+}

--- a/front/src/components/ResizeableDiv/ResizeableDiv.tsx
+++ b/front/src/components/ResizeableDiv/ResizeableDiv.tsx
@@ -1,0 +1,86 @@
+import React, { useState, useRef, useEffect, useCallback } from "react";
+
+type ResizableContainerProps = {
+  children: React.ReactNode[];
+};
+
+const ResizableContainer: React.FC<ResizableContainerProps> = ({ children }) => {
+  const initialWidth = 100 / children.length;
+  const [widths, setWidths] = useState<number[]>(
+    new Array(children.length).fill(initialWidth),
+  );
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const [draggingDivIndex, setDraggingDivIndex] = useState<number | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const handleMouseDown = (index: number): void => {
+    setIsDragging(true);
+    setDraggingDivIndex(index);
+  };
+
+  const handleMouseUp = (): void => {
+    setIsDragging(false);
+    setDraggingDivIndex(null);
+  };
+
+  const handleMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (isDragging && containerRef.current !== null && draggingDivIndex !== null) {
+        const totalWidth = containerRef.current.getBoundingClientRect().width;
+        const newWidth =
+          ((e.clientX - containerRef.current.getBoundingClientRect().left) / totalWidth) *
+          100;
+        const offset = newWidth - widths[draggingDivIndex];
+
+        const updatedWidths = [...widths];
+        updatedWidths[draggingDivIndex] = newWidth;
+        updatedWidths[draggingDivIndex + 1] -= offset;
+
+        setWidths(updatedWidths);
+      }
+    },
+    [isDragging, draggingDivIndex, widths],
+  );
+
+  useEffect(() => {
+    window.addEventListener("mouseup", handleMouseUp);
+    window.addEventListener("mousemove", handleMouseMove);
+
+    return () => {
+      window.removeEventListener("mouseup", handleMouseUp);
+      window.removeEventListener("mousemove", handleMouseMove);
+    };
+  }, [handleMouseMove]);
+
+  return (
+    <div ref={containerRef} style={{ display: "flex", width: "100%" }}>
+      {React.Children.map(children, (child, index) => (
+        <div
+          style={{
+            width: `${widths[index] || initialWidth}%`,
+            position: "relative",
+            minWidth: "200px",
+          }}
+        >
+          {child}
+          {index < children.length - 1 && (
+            <div
+              style={{
+                cursor: "ew-resize",
+                position: "absolute",
+                top: 0,
+                right: 0,
+                width: "3px",
+                height: "100vh",
+                backgroundColor: "lightgray",
+              }}
+              onMouseDown={() => handleMouseDown(index)}
+            ></div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ResizableContainer;

--- a/front/src/pages/EditContainer/EditContainer.style.tsx
+++ b/front/src/pages/EditContainer/EditContainer.style.tsx
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+`;

--- a/front/src/pages/EditContainer/EditContainer.tsx
+++ b/front/src/pages/EditContainer/EditContainer.tsx
@@ -1,5 +1,11 @@
+import Sidebar from "./components/Sidebar/Sidebar";
+import * as S from "./EditContainer.style";
 function EditContainer() {
-  return <div>EditContainer</div>;
+  return (
+    <S.Container>
+      <Sidebar />
+    </S.Container>
+  );
 }
 
 export default EditContainer;

--- a/front/src/pages/EditContainer/components/Sidebar/ContextMenu.style.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/ContextMenu.style.tsx
@@ -1,0 +1,39 @@
+import styled from "styled-components";
+import * as COLOR from "../../../../constants/color";
+import * as FONT from "../../../../constants/font";
+
+interface PosType {
+  y: number;
+  x: number;
+}
+
+export const Menus = styled.div<PosType>`
+  color: ${COLOR.White};
+  position: absolute;
+  top: ${(props) => `${props.y}px`};
+  left: ${(props) => `${props.x}px`};
+  z-index: 10;
+  font-size: ${FONT.S};
+`;
+
+export const Menu = styled.div`
+  padding: 10px 30px;
+  width: 250px;
+  background-color: ${COLOR.Gray8};
+  border-bottom: 1px solid ${COLOR.Gray6};
+
+  &:hover {
+    background-color: ${COLOR.Gray7};
+  }
+
+  &:first-child {
+    border-top-left-radius: 7px;
+    border-top-right-radius: 7px;
+  }
+
+  &:last-child {
+    border-bottom-left-radius: 7px;
+    border-bottom-right-radius: 7px;
+    border-bottom: none;
+  }
+`;

--- a/front/src/pages/EditContainer/components/Sidebar/ContextMenu.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/ContextMenu.tsx
@@ -32,6 +32,8 @@ function ContextMenu({ info, setSelectedInfo }: PropsType) {
   return (
     <S.Menus ref={contextMenuRef} y={info.event.clientY} x={info.event.clientX}>
       {isFile && <S.Menu>저장</S.Menu>}
+      {!isFile && <S.Menu>파일 추가</S.Menu>}
+      {!isFile && <S.Menu>폴더 추가</S.Menu>}
       <S.Menu>이름 변경</S.Menu>
       <S.Menu>삭제</S.Menu>
     </S.Menus>

--- a/front/src/pages/EditContainer/components/Sidebar/ContextMenu.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/ContextMenu.tsx
@@ -1,0 +1,41 @@
+import { Dispatch, SetStateAction, useEffect, useRef } from "react";
+import * as T from "../../../../types/FileTree";
+import * as S from "./ContextMenu.style";
+
+type PropsType = {
+  info: T.InfoType;
+  setSelectedInfo: Dispatch<SetStateAction<T.InfoType | null>>;
+};
+
+function ContextMenu({ info, setSelectedInfo }: PropsType) {
+  const contextMenuRef = useRef<HTMLDivElement>(null);
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (
+      contextMenuRef.current &&
+      !contextMenuRef.current.contains(event.target as Node)
+    ) {
+      setSelectedInfo(null);
+    }
+  };
+
+  const isFile = info.node.title?.toString().includes(".");
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  return (
+    <S.Menus ref={contextMenuRef} y={info.event.clientY} x={info.event.clientX}>
+      {isFile && <S.Menu>저장</S.Menu>}
+      <S.Menu>이름 변경</S.Menu>
+      <S.Menu>삭제</S.Menu>
+    </S.Menus>
+  );
+}
+
+export default ContextMenu;

--- a/front/src/pages/EditContainer/components/Sidebar/MSidebar.style.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/MSidebar.style.tsx
@@ -1,0 +1,42 @@
+import styled from "styled-components";
+import * as COLOR from "../../../../constants/color";
+
+type Props = {
+  isSidebarOpened?: boolean;
+};
+
+export const Container = styled.div`
+  height: 100vh;
+  background-color: ${COLOR.Gray10};
+  width: 50px;
+`;
+
+export const Icons = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: ${COLOR.White};
+`;
+
+export const IconWrapper = styled.div<Props>`
+  position: relative;
+  padding: 10px;
+  background-color: ${(props) => (props.isSidebarOpened ? COLOR.Gray11 : COLOR.Gray10)};
+
+  &:hover {
+    cursor: pointer;
+    background-color: ${COLOR.Gray11};
+  }
+
+  &::before {
+    content: "";
+    display: ${(props) => (props.isSidebarOpened ? COLOR.Purple1 : "none")};
+    position: absolute;
+    width: 2px;
+    height: 30px;
+    background-color: ${COLOR.Purple1};
+    top: 50%;
+    left: 0;
+    transform: translateY(-50%);
+  }
+`;

--- a/front/src/pages/EditContainer/components/Sidebar/MSidebar.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/MSidebar.tsx
@@ -1,0 +1,38 @@
+import * as S from "./MSidebar.style";
+import * as Icon from "../../../../components/Icon";
+import React from "react";
+
+type PropsType = {
+  isSidebarOpened: boolean;
+  setIsSidebarOpened: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+function MSidebar({ isSidebarOpened, setIsSidebarOpened }: PropsType) {
+  const handleSidebar = () => {
+    setIsSidebarOpened((prev) => !prev);
+  };
+
+  return (
+    <S.Container>
+      <S.Icons>
+        <S.IconWrapper onClick={handleSidebar} isSidebarOpened={isSidebarOpened}>
+          <Icon.Space size={25} />
+        </S.IconWrapper>
+
+        <S.IconWrapper>
+          <Icon.Save size={25} />
+        </S.IconWrapper>
+
+        <S.IconWrapper>
+          <Icon.Share size={25} />
+        </S.IconWrapper>
+
+        <S.IconWrapper>
+          <Icon.Chat size={25} />
+        </S.IconWrapper>
+      </S.Icons>
+    </S.Container>
+  );
+}
+
+export default MSidebar;

--- a/front/src/pages/EditContainer/components/Sidebar/Sidebar.style.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/Sidebar.style.tsx
@@ -1,8 +1,13 @@
 import styled from "styled-components";
 import * as COLOR from "../../../../constants/color";
+
 export const Container = styled.div`
   height: 100vh;
   min-width: 100px;
   background-color: ${COLOR.Gray9};
   width: 300px;
+`;
+
+export const MobileContainer = styled.div`
+  display: flex;
 `;

--- a/front/src/pages/EditContainer/components/Sidebar/Sidebar.style.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/Sidebar.style.tsx
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+import * as COLOR from "../../../../constants/color";
+export const Container = styled.div`
+  height: 100vh;
+  min-width: 100px;
+  background-color: ${COLOR.Gray9};
+  width: 300px;
+`;

--- a/front/src/pages/EditContainer/components/Sidebar/Sidebar.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/Sidebar.tsx
@@ -1,12 +1,37 @@
 import * as S from "./Sidebar.style";
 import SidebarFileTree from "./SidebarFileTree";
 import SidebarHeader from "./SidebarHeader";
+import { Desktop, Mobile } from "../../../../components/Responsive";
+import MSidebar from "./MSidebar";
+import { useState } from "react";
+
 function Sidebar() {
+  const [isSidebarOpened, setIsSidebarOpened] = useState(false);
+
   return (
-    <S.Container>
-      <SidebarHeader />
-      <SidebarFileTree />/
-    </S.Container>
+    <>
+      <Desktop>
+        <S.Container>
+          <SidebarHeader />
+          <SidebarFileTree />/
+        </S.Container>
+      </Desktop>
+
+      <Mobile>
+        <S.MobileContainer>
+          <MSidebar
+            isSidebarOpened={isSidebarOpened}
+            setIsSidebarOpened={setIsSidebarOpened}
+          />
+          {isSidebarOpened && (
+            <S.Container>
+              <SidebarHeader />
+              <SidebarFileTree />/
+            </S.Container>
+          )}
+        </S.MobileContainer>
+      </Mobile>
+    </>
   );
 }
 

--- a/front/src/pages/EditContainer/components/Sidebar/Sidebar.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/Sidebar.tsx
@@ -1,0 +1,13 @@
+import * as S from "./Sidebar.style";
+import SidebarFileTree from "./SidebarFileTree";
+import SidebarHeader from "./SidebarHeader";
+function Sidebar() {
+  return (
+    <S.Container>
+      <SidebarHeader />
+      <SidebarFileTree />/
+    </S.Container>
+  );
+}
+
+export default Sidebar;

--- a/front/src/pages/EditContainer/components/Sidebar/SidebarFileTree.style.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/SidebarFileTree.style.tsx
@@ -1,0 +1,6 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  padding: 5px 10px;
+  height: calc(100vh - 30px);
+`;

--- a/front/src/pages/EditContainer/components/Sidebar/SidebarFileTree.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/SidebarFileTree.tsx
@@ -2,6 +2,8 @@ import Tree, { TreeNode, TreeNodeProps, TreeProps } from "rc-tree";
 import "rc-tree/assets/index.css";
 import * as T from "../../../../types/FileTree";
 import * as S from "./SidebarFileTree.style";
+import * as FONT from "../../../../constants/font";
+import * as COLOR from "../../../../constants/color";
 import { getIcon } from "../../../../components/FileIcon";
 import { useRecoilValue } from "recoil";
 import { isExtandAllFilesState } from "../../../../recoil/CodeEditorState";
@@ -40,7 +42,7 @@ const fileData: T.FileData = {
 function SidebarFileTree() {
   const [selectedInfo, setSelectedInfo] = useState<T.InfoType | null>(null);
   const isExtandAllFiles = useRecoilValue<number>(isExtandAllFilesState);
-  
+
   // 파일시스템 요소 타입(파일, 혹은 디렉토리)에 따른 아이콘 생성 로직
   const switcherIcon: TreeProps["switcherIcon"] = (fsElement) => {
     let iconType: string;
@@ -78,9 +80,9 @@ function SidebarFileTree() {
             title={fsElement.title}
             key={fsElement.key}
             style={{
-              fontWeight: "bold",
-              color: "#a9a9a9",
-              fontSize: "13px",
+              fontWeight: FONT.Bold,
+              color: COLOR.Gray3,
+              fontSize: FONT.S,
             }}
           >
             {getTreeNode(fsElement.children)}
@@ -94,9 +96,8 @@ function SidebarFileTree() {
             title={fsElement.title}
             key={fsElement.key}
             style={{
-              fontWeight: "normal",
-              color: "#a9a9a9",
-              fontSize: "13px",
+              color: COLOR.Gray3,
+              fontSize: FONT.S,
             }}
           />
         );

--- a/front/src/pages/EditContainer/components/Sidebar/SidebarFileTree.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/SidebarFileTree.tsx
@@ -1,0 +1,133 @@
+import Tree, { TreeNode, TreeNodeProps, TreeProps } from "rc-tree";
+import "rc-tree/assets/index.css";
+import * as T from "../../../../types/FileTree";
+import * as S from "./SidebarFileTree.style";
+import { getIcon } from "../../../../components/FileIcon";
+import { useRecoilValue } from "recoil";
+import { isExtandAllFilesState } from "../../../../recoil/CodeEditorState";
+import ContextMenu from "./ContextMenu";
+import { useState } from "react";
+
+// 임시 데이터
+const treeData: T.FileTreeType = [
+  {
+    key: "/hello/",
+    title: "hello",
+    children: [
+      {
+        key: "/hello/duck/",
+        title: "duck",
+        children: [{ key: "/hello/duck/duck1.css", title: "duck1.css" }],
+      },
+      {
+        key: "/hello/bird",
+        title: "bird",
+        children: [
+          { key: "/hello/bird/bird1.png", title: "bird1.png" },
+          { key: "/hello/bird/bird2.txt", title: "bird2.txt" },
+        ],
+      },
+    ],
+  },
+];
+
+const fileData: T.FileData = {
+  "/hello/duck/duck1.css": "duck1.css 파일 내용",
+  "/hello/bird/bird1.png": "bird1.png 파일 내용",
+  "/hello/bird/bird2.txt": "bird2.txt 파일 내용",
+};
+
+function SidebarFileTree() {
+  const [selectedInfo, setSelectedInfo] = useState<T.InfoType | null>(null);
+  const isExtandAllFiles = useRecoilValue<number>(isExtandAllFilesState);
+  
+  // 파일시스템 요소 타입(파일, 혹은 디렉토리)에 따른 아이콘 생성 로직
+  const switcherIcon: TreeProps["switcherIcon"] = (fsElement) => {
+    let iconType: string;
+
+    if (isFile(fsElement)) iconType = getFileType(fsElement) as string;
+    else iconType = fsElement.expanded ? "openDirectory" : "closedDirectory";
+
+    return getIcon(iconType);
+  };
+
+  const isFile = (fsElement: TreeNodeProps) => {
+    return fsElement.isLeaf ? true : false;
+  };
+
+  const getFileType = (fsElement: TreeNodeProps) => {
+    return fsElement.title?.toString().split(".").pop();
+  };
+
+  // 파일이 선택됐을 때 실행할 로직
+  const onSelect: TreeProps["onSelect"] = (checkedKeys) => {
+    if (fileData[checkedKeys[0]]) alert(`${fileData[checkedKeys[0]]}`);
+  };
+
+  const onRightClick: TreeProps["onRightClick"] = (info) => {
+    setSelectedInfo(info);
+  };
+
+  // 트리 노드 생성 함수
+  const getTreeNode = (data: T.FileTreeType) => {
+    return data.map((fsElement) => {
+      // 폴더인 경우
+      if (fsElement.children) {
+        return (
+          <TreeNode
+            title={fsElement.title}
+            key={fsElement.key}
+            style={{
+              fontWeight: "bold",
+              color: "#a9a9a9",
+              fontSize: "13px",
+            }}
+          >
+            {getTreeNode(fsElement.children)}
+          </TreeNode>
+        );
+      }
+      // 파일인 경우
+      else {
+        return (
+          <TreeNode
+            title={fsElement.title}
+            key={fsElement.key}
+            style={{
+              fontWeight: "normal",
+              color: "#a9a9a9",
+              fontSize: "13px",
+            }}
+          />
+        );
+      }
+    });
+  };
+
+  // 트리 노드 생성
+  const treeNodes = getTreeNode(treeData);
+
+  return (
+    <S.Container key={isExtandAllFiles}>
+      {selectedInfo && (
+        <ContextMenu
+          info={selectedInfo as T.InfoType}
+          setSelectedInfo={setSelectedInfo}
+        />
+      )}
+      <Tree
+        defaultExpandAll={false}
+        onSelect={onSelect}
+        onRightClick={onRightClick}
+        switcherIcon={switcherIcon}
+        showIcon={false}
+        expandAction={"click"}
+        autoExpandParent={true}
+      >
+        {treeNodes}
+      </Tree>
+    </S.Container>
+  );
+}
+
+export default SidebarFileTree;

--- a/front/src/pages/EditContainer/components/Sidebar/SidebarHeader.style.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/SidebarHeader.style.tsx
@@ -1,0 +1,28 @@
+import styled from "styled-components";
+import * as COLOR from "../../../../constants/color";
+import * as FONT from "../../../../constants/font";
+
+export const Header = styled.div`
+  display: flex;
+  padding: 10px;
+  background-color: ${COLOR.Gray10};
+  justify-content: space-between;
+  color: white;
+  height: 30px;
+  align-items: center;
+`;
+
+export const ProjectText = styled.span`
+  font-size: ${FONT.M};
+`;
+
+export const Icons = styled.div`
+  display: flex;
+  gap: 5px;
+`;
+
+export const IconWrapper = styled.div`
+  &:hover {
+    cursor: pointer;
+  }
+`;

--- a/front/src/pages/EditContainer/components/Sidebar/SidebarHeader.style.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/SidebarHeader.style.tsx
@@ -7,7 +7,7 @@ export const Header = styled.div`
   padding: 10px;
   background-color: ${COLOR.Gray10};
   justify-content: space-between;
-  color: white;
+  color: ${COLOR.White};
   height: 30px;
   align-items: center;
 `;

--- a/front/src/pages/EditContainer/components/Sidebar/SidebarHeader.tsx
+++ b/front/src/pages/EditContainer/components/Sidebar/SidebarHeader.tsx
@@ -1,0 +1,35 @@
+import * as S from "./SidebarHeader.style";
+import * as Icon from "../../../../components/Icon";
+import { useRecoilState } from "recoil";
+
+import { isExtandAllFilesState } from "../../../../recoil/CodeEditorState";
+
+function SidebarHeader() {
+  const [isExtandAllFiles, setIsExtandAllFilesState] =
+    useRecoilState<number>(isExtandAllFilesState);
+
+  const handleCloseFileTree = () => {
+    setIsExtandAllFilesState(isExtandAllFiles + 1);
+  };
+
+  return (
+    <S.Header>
+      <S.ProjectText>프로젝트</S.ProjectText>
+      <S.Icons>
+        <S.IconWrapper>
+          <Icon.Plus />
+        </S.IconWrapper>
+
+        <S.IconWrapper onClick={handleCloseFileTree}>
+          <Icon.FolderClose />
+        </S.IconWrapper>
+
+        <S.IconWrapper>
+          <Icon.Refresh />
+        </S.IconWrapper>
+      </S.Icons>
+    </S.Header>
+  );
+}
+
+export default SidebarHeader;

--- a/front/src/recoil/CodeEditorState.ts
+++ b/front/src/recoil/CodeEditorState.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const isExtandAllFilesState = atom<number>({
+  key: "isExtandAllState",
+  default: 0,
+});

--- a/front/src/types/FileTree.ts
+++ b/front/src/types/FileTree.ts
@@ -1,0 +1,18 @@
+import { DataNode, EventDataNode } from "rc-tree/lib/interface";
+
+export interface FileType {
+  key: string;
+  title: string;
+  children?: FileTreeType;
+}
+
+export type FileTreeType = FileType[];
+
+export type FileData = {
+  [key: string]: string;
+};
+
+export type InfoType = {
+  event: React.MouseEvent<Element, MouseEvent>;
+  node: EventDataNode<DataNode>;
+};


### PR DESCRIPTION
- 사이드 바 UI
  - 파일 트리 전체 닫기 구현 
- 파일 트리 구조 UI
  - 노드 오른쪽 클릭시 Context Menu 출력
    - 파일일 경우 - 저장, 이름 변경, 삭제
    - 폴더일 경우 - 파일 추가, 폴더 추가, 이름 변경, 삭제  
  - 파일 형식에 따른 아이콘 자동 지정 
- 모바일 전용 사이드 바
  - 사이드 바 UI를 버튼을 통한 토글식 렌더링이 되도록 구현

## PC
![image](https://github.com/Goorm-OGJG/Web-IDE/assets/79975172/8bd41749-cd22-4860-a6cf-b8bd13c51263)

## Mobile
![image](https://github.com/Goorm-OGJG/Web-IDE/assets/79975172/bae616a0-302b-4658-b561-96ccf48a39dd)
![image](https://github.com/Goorm-OGJG/Web-IDE/assets/79975172/c8978c27-9185-4000-97b9-efa25f6b5072)


