### PR TITLE
Feat : OW-39 회원 관리 API 및 테스트 추가

### DIFF
--- a/back/src/main/java/com/ogjg/back/user/controller/UserController.java
+++ b/back/src/main/java/com/ogjg/back/user/controller/UserController.java
@@ -1,0 +1,66 @@
+package com.ogjg.back.user.controller;
+
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.response.ApiResponse;
+import com.ogjg.back.user.dto.request.InfoUpdateRequest;
+import com.ogjg.back.user.dto.request.PasswordUpdateRequest;
+import com.ogjg.back.user.dto.response.ImgUpdateResponse;
+import com.ogjg.back.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    // todo : update 로직 응답 값 정의 및 추가 필요, 토큰 추가 시 email 정보 추가
+    /**
+     * 프로필 사진 업로드(변경 시 덮어씀)
+     */
+    @PatchMapping("/img")
+    public ApiResponse<ImgUpdateResponse> updateImg(@RequestParam("img") MultipartFile imgFile) {
+        String loginEmail = "ogjg1234@naver.com";
+
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS,
+                userService.updateImg(imgFile, loginEmail)
+        );
+    }
+
+    /**
+     * 회원 정보 변경
+     */
+    @PatchMapping("/info")
+    public ApiResponse<Void> updateInfo(@RequestBody InfoUpdateRequest request) {
+        String loginEmail = "ogjg1234@naver.com";
+
+        userService.updateInfo(request, loginEmail);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
+    /**
+     * 회원 비밀번호 변경
+     */
+    @PatchMapping("/password")
+    public ApiResponse<Void> updatePassword(@RequestBody PasswordUpdateRequest request) {
+        String loginEmail = "ogjg1234@naver.com";
+
+        userService.updatePassword(request, loginEmail);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
+    /**
+     * 회원 탈퇴
+     */
+    @PatchMapping("/deactivate")
+    public ApiResponse<Void> deactivate() {
+        String loginEmail = "ogjg1234@naver.com";
+
+        userService.deactivate(loginEmail);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/user/domain/User.java
+++ b/back/src/main/java/com/ogjg/back/user/domain/User.java
@@ -2,16 +2,17 @@ package com.ogjg.back.user.domain;
 
 import com.ogjg.back.user.dto.request.UserRequest;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "users")
-@Getter
-public class User {
+import static lombok.AccessLevel.*;
 
+@Getter
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Table(name = "users")
+public class User {
     @Id
     private String email;
 
@@ -28,19 +29,40 @@ public class User {
     @JoinColumn(name = "email_auth_id")
     private EmailAuth emailAuth;
 
-    public void userCancel(){
-        this.userStatus = UserStatus.INACTIVE;
-    }
-
     public User(UserRequest userRequest) {
         this.email = userRequest.getEmail();
         this.password = userRequest.getPassword();
         this.name = userRequest.getName();
     }
 
+    @Builder
+    public User(String email, String password, String name, String userImg, UserStatus userStatus, EmailAuth emailAuth) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.userImg = userImg;
+        this.userStatus = userStatus;
+        this.emailAuth = emailAuth;
+    }
+
+    public User updateImg(String aws_url) {
+        this.userImg = aws_url;
+        return this;
+    }
+
+    public User updateInfo(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public User updatePassword(String password) {
+        this.password = password;
+        return this;
+    }
+
+    public User deactivate() {
+        this.userStatus = UserStatus.INACTIVE;
+        return this;
+    }
 }
 
-enum UserStatus{
-    ACTIVE,
-    INACTIVE
-}

--- a/back/src/main/java/com/ogjg/back/user/domain/UserStatus.java
+++ b/back/src/main/java/com/ogjg/back/user/domain/UserStatus.java
@@ -1,0 +1,6 @@
+package com.ogjg.back.user.domain;
+
+public enum UserStatus {
+    ACTIVE,
+    INACTIVE
+}

--- a/back/src/main/java/com/ogjg/back/user/dto/request/ImgUpdateRequest.java
+++ b/back/src/main/java/com/ogjg/back/user/dto/request/ImgUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.ogjg.back.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ImgUpdateRequest {
+    MultipartFile img;
+}

--- a/back/src/main/java/com/ogjg/back/user/dto/request/InfoUpdateRequest.java
+++ b/back/src/main/java/com/ogjg/back/user/dto/request/InfoUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.ogjg.back.user.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class InfoUpdateRequest {
+    String name;
+}

--- a/back/src/main/java/com/ogjg/back/user/dto/request/PasswordUpdateRequest.java
+++ b/back/src/main/java/com/ogjg/back/user/dto/request/PasswordUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.ogjg.back.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class PasswordUpdateRequest {
+    String password;
+}

--- a/back/src/main/java/com/ogjg/back/user/dto/response/ImgUpdateResponse.java
+++ b/back/src/main/java/com/ogjg/back/user/dto/response/ImgUpdateResponse.java
@@ -1,0 +1,21 @@
+package com.ogjg.back.user.dto.response;
+
+import com.ogjg.back.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ImgUpdateResponse {
+    String url;
+
+    @Builder
+    public ImgUpdateResponse(String url) {
+        this.url = url;
+    }
+
+    public static ImgUpdateResponse of(User user) {
+        return ImgUpdateResponse.builder()
+                .url(user.getUserImg())
+                .build();
+    }
+}

--- a/back/src/main/java/com/ogjg/back/user/exception/NotFoundUser.java
+++ b/back/src/main/java/com/ogjg/back/user/exception/NotFoundUser.java
@@ -5,11 +5,12 @@ import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.exception.ErrorData;
 
 public class NotFoundUser extends CustomException {
-    public NotFoundUser(ErrorCode errorCode) {
-        super(errorCode);
+
+    public NotFoundUser() {
+        super(ErrorCode.NOT_FOUND_USER);
     }
 
-    public NotFoundUser(ErrorCode errorCode, ErrorData errorData) {
-        super(errorCode, errorData);
+    public NotFoundUser(ErrorData errorData) {
+        super(ErrorCode.NOT_FOUND_USER, errorData);
     }
 }

--- a/back/src/main/java/com/ogjg/back/user/repository/UserRepository.java
+++ b/back/src/main/java/com/ogjg/back/user/repository/UserRepository.java
@@ -5,8 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User, Long> {
-
+public interface UserRepository extends JpaRepository<User, String> {
     Optional<User> findByEmail(String email);
-
 }

--- a/back/src/main/java/com/ogjg/back/user/service/UserService.java
+++ b/back/src/main/java/com/ogjg/back/user/service/UserService.java
@@ -1,0 +1,55 @@
+package com.ogjg.back.user.service;
+
+import com.ogjg.back.user.domain.User;
+import com.ogjg.back.user.dto.request.InfoUpdateRequest;
+import com.ogjg.back.user.dto.request.PasswordUpdateRequest;
+import com.ogjg.back.user.dto.response.ImgUpdateResponse;
+import com.ogjg.back.user.exception.NotFoundUser;
+import com.ogjg.back.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ImgUpdateResponse updateImg(MultipartFile imgFile, String loginEmail) {
+        User findUser = findByEmail(loginEmail);
+
+        // todo : 이미지 데이터 aws 업로드 로직 추가
+        // S3에 파일 데이터 저장 후, 경로 반환
+        String aws_url = "temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/" +findUser.getEmail()+"/{fileName}";
+
+        User user = findUser.updateImg(aws_url);
+        return ImgUpdateResponse.of(user);
+    }
+
+    @Transactional
+    public void updateInfo(InfoUpdateRequest request, String loginEmail) {
+        User findUser = findByEmail(loginEmail);
+        findUser.updateInfo(request.getName());
+    }
+
+    @Transactional
+    public void updatePassword(PasswordUpdateRequest request, String loginEmail) {
+        User findUser = findByEmail(loginEmail);
+        findUser.updatePassword(request.getPassword());
+    }
+
+    @Transactional
+    public void deactivate(String loginEmail) {
+        User findUser = findByEmail(loginEmail);
+        findUser.deactivate();
+    }
+
+    @Transactional(readOnly = true)
+    protected User findByEmail(String email) {
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new NotFoundUser());
+    }
+}

--- a/back/src/test/java/com/ogjg/back/user/domain/UserTest.java
+++ b/back/src/test/java/com/ogjg/back/user/domain/UserTest.java
@@ -1,0 +1,74 @@
+package com.ogjg.back.user.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class UserTest {
+
+    private User user;
+
+    @BeforeEach
+    public void setUp() {
+        user = User.builder()
+                .email("ogjg1234@naver.com")
+                .password("1q2w3e4r!")
+                .name("김회원")
+                .userImg("temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/" + 1L + "/{fileName}")
+                .userStatus(UserStatus.ACTIVE)
+                .build();
+    }
+
+    @DisplayName("회원 이미지 업로드")
+    @Test
+    public void updateImg() throws Exception {
+        //given
+        String newUrl = "updated.img";
+
+        //when
+        User updatedUser = user.updateImg(newUrl);
+
+        //then
+        assertThat(updatedUser.getUserImg()).isEqualTo(newUrl);
+     }
+
+    @DisplayName("회원 정보 변경")
+    @Test
+    public void updateInfo() throws Exception {
+        //given
+        String newName = "김회장";
+
+        //when
+        User updatedUser = user.updateInfo(newName);
+
+        //then
+        assertThat(updatedUser.getName()).isEqualTo(newName);
+    }
+
+    @DisplayName("회원 비밀번호 변경")
+    @Test
+    public void updatePassword() throws Exception {
+        //given
+        String newPassword = "1q2w3e4r@";
+
+        //when
+        User updatedUser = user.updatePassword(newPassword);
+
+        //then
+        assertThat(updatedUser.getPassword()).isEqualTo(newPassword);
+    }
+
+    @DisplayName("회원 탈퇴")
+    @Test
+    public void deactivate() throws Exception {
+        //given
+
+        //when
+        User updatedUser = user.deactivate();
+
+        //then
+        assertThat(updatedUser.getUserStatus()).isEqualTo(UserStatus.INACTIVE);
+    }
+}

--- a/back/src/test/java/com/ogjg/back/user/service/UserServiceTest.java
+++ b/back/src/test/java/com/ogjg/back/user/service/UserServiceTest.java
@@ -1,0 +1,64 @@
+package com.ogjg.back.user.service;
+
+import com.ogjg.back.user.domain.User;
+import com.ogjg.back.user.domain.UserStatus;
+import com.ogjg.back.user.exception.NotFoundUser;
+import com.ogjg.back.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+public class UserServiceTest {
+
+    static User user;
+    @Autowired
+    UserService userService;
+    @Autowired
+    UserRepository userRepository;
+
+    @BeforeAll
+    public static void setUp() {
+        user = User.builder()
+                .email("ogjg1234@naver.com")
+                .password("1q2w3e4r!")
+                .name("김회원")
+                .userImg("temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/" + 1L + "/{fileName}")
+                .userStatus(UserStatus.ACTIVE)
+                .build();
+    }
+
+    @DisplayName("회원 조회")
+    @Test
+    @Transactional
+    public void findByEmail() throws Exception {
+        //given
+        String email = "ogjg1234@naver.com";
+        userRepository.save(user);
+
+        //when
+        User findUser = userService.findByEmail(email);
+
+        //then
+        assertThat(findUser.getEmail()).isEqualTo(user.getEmail());
+    }
+
+    @DisplayName("회원 조회 예외 - 존재하지 않는 회원")
+    @Test
+    @Transactional
+    public void cannotFoundUser() throws Exception {
+        //given
+        String wrongEmail = "ogjg5678@naver.com";
+        userRepository.save(user);
+
+        //when, then
+        assertThatThrownBy(() -> userService.findByEmail(wrongEmail))
+                .isInstanceOf(NotFoundUser.class);
+    }
+}


### PR DESCRIPTION
### 기능 구현
- [x] API 추가
  - [x] 회원 프로필 사진 업로드 기능 추가 (s3 저장 로직 추후에 추가 예정)
  - [x] 회원 정보 변경 기능 추가
    - updateInfo 메서드는 회원의 이름 정보만 수정한다. 확장을 고려해 info라고 네이밍했다.
  - [x] 회원 비밀번호 변경 기능 추가
  - [x] 중복되는 회원 탈퇴 기능 통합
    - update로 회원 탈퇴를 관리
  - [x] UserStatus enum 클래스 파일로 분리
- [x] 테스트 추가
  - [x] 추가한 모든 회원 관리 기능 단위테스트 추가
  - [x] service 테스트 추가

### todo 
- 임시 구현 기능
  - 이미지 업로드 기능 임시 구현 상태
      - 아직 s3에 연동하지 않아서 임시 aws url을 상수값으로 만들어서 응답에 사용했다.
      - s3 업로드 기능 추가가 필요하다.
  - 토큰 이메일 정보 상수값으로 사용해서 토큰 적용 시 교체 필요
- 논의가 필요한 내용
  - update로직의 응답 값에 대한 논의 필요
- 추가할 내용
  - rest docs 의존성 추가 및 mock 테스트 추가

