### PR TITLE
백엔드 배포 중 발생하는 에러 해결

### DIFF
--- a/.github/workflows/backend_cicd.yml
+++ b/.github/workflows/backend_cicd.yml
@@ -16,6 +16,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -46,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v3
+
       - name: Download Build Artifact
         uses: actions/download-artifact@v3
         with:
@@ -65,6 +68,9 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/web-ide:latest
 
+      - name: Zip the docker-compose file
+        run: zip -j deployment ./back/docker-compose.yml
+
       - name: Deploy to Elastic Beanstalk
         uses: einaregilsson/beanstalk-deploy@v21
         with:
@@ -74,4 +80,4 @@ jobs:
           environment_name: OGJG-env
           version_label: OGJG_Deploy-${{ github.SHA }}
           region: ${{ secrets.BACK_AWS_REGION }}
-          deployment_package: ./back/docker-compose.yml
+          deployment_package: deployment.zip

--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -17,6 +17,6 @@ ENV LANG C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm
 ENV PATH=$PATH:/usr/lib/jvm/default-jvm/bin
 
-COPY web-ide.jar /app/
+COPY back-0.0.1-SNAPSHOT.jar /app/
 
-ENTRYPOINT ["java", "-jar", "/app/web-ide.jar"]
+ENTRYPOINT ["java", "-jar", "/app/back-0.0.1-SNAPSHOT.jar"]

--- a/back/src/main/java/com/ogjg/back/config/HealthCheck.java
+++ b/back/src/main/java/com/ogjg/back/config/HealthCheck.java
@@ -1,0 +1,15 @@
+package com.ogjg.back.config;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+public class HealthCheck {
+
+    @RequestMapping("/health")
+    public ResponseEntity<?> healthCheck() {
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
### 배포 에러 원인
배포시 docker-compose.yml을 압축하여 배포를 진행하는데 경로까지 압축이 되어 파일을 인식하지 못하는 상황이 발생했습니다.
예를 들어, `./back/docker-compose.yml`을 압축하게 되면 `back`폴더까지 압축되어 EC2에서 인식을 하지 못했습니다.

### 해결
- `-j` 옵션을 사용해 해당하는 파일만 압축하도록 변경

### health check
- 상태 관리 통과를 위해 `HealthCheck API`를 작성
- `HealthCheck API` 요청 허가를 위해 임시로 SecurityConfig를 생성해 모든 URL에 대한 허용