### PR TITLE
Feat : OW-51 rest-docs 의존성 및 html 복사 task 추가

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.1.3'
     id 'io.spring.dependency-management' version '1.1.3'
+    id "org.asciidoctor.jvm.convert" version "3.3.2"
 }
 
 group = 'com.ogjg'
@@ -15,6 +16,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    asciidoctorExt
 }
 
 repositories {
@@ -46,8 +48,36 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // rest-docs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+jar {
+    enabled = false
+}
+
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
+test {
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
+}
+
+task copyDocument(type: Copy) {
+    dependsOn asciidoctor
+    from file("${asciidoctor.outputDir}")
+    into file("build/resources/main/static")
 }

--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -1,0 +1,31 @@
+= Web-IDE 프로젝트 API 문서
+:toc: left
+:source-highlighter: highlightjs
+:sectlinks:
+
+== 회원 API
+
+=== 회원 프로필 이미지 업로드
+이미지를 s3에 업로드 하고, url을 db에 저장합니다.
+
+=== 회원 비밀번호 변경
+회원 정보를 변경합니다. 현재는 변경 가능한 정보가 이름뿐입니다.
+
+=== 회원 탈퇴
+회원 정보를 변경합니다. 현재는 변경 가능한 정보가 이름뿐입니다.
+
+== 컨테이너 API
+
+=== API1
+api1
+
+=== API2
+api2
+
+== 컨테이너 생성 API
+:toc:
+
+=== API1
+api1
+
+=== AP


### PR DESCRIPTION
- [x] spring-restdocs 관련 의존성 추가
- [x] 생성된 html 파일을 지정한 위치로 복사하는 copyDocument task 추가

###  copyDocument task 추가 설명
기본적으로 asciidoctor 의존성은 build/docs/asciidoc/ 경로에 html 파일을 생성합니다.
다음 태스크를 실행하면, build 파일 내부에 resource 경로에 해당 html 파일이 복사됩니다.
```
task copyDocument(type: Copy) {
    dependsOn asciidoctor
    from file("${asciidoctor.outputDir}")
    into file("build/resources/main/static")
}
```
즉, 로컬에서 실행해서  8080포트를 실행한다면, http://localhost:8080/ 을 실행시 doc이 랜더링되도록 설정했습니다.

주의하실 점은 갱신된 test를 실행한 후에 문서를 갱신하고 싶다면, copyDocument task를 직접 실행해줘야 합니다.
- `./gradlew copyDocument`를 실행하시면 됩니다.
- 인텔리제이에서 아이콘을 클릭해 실행시키셔도 됩니다.
