### PR TITLE
Feat : JwtToken, EmailAuth 기능 추가

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/back/src/main/java/com/ogjg/back/common/exception/CustomException.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/CustomException.java
@@ -8,12 +8,25 @@ public abstract class CustomException extends RuntimeException {
     private final ErrorCode errorCode;
     private ErrorData errorData;
 
-    public CustomException(ErrorCode errorCode) {
+    public CustomException(
+            ErrorCode errorCode
+    ) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 
-    public CustomException(ErrorCode errorCode, ErrorData errorData) {
+    public CustomException(
+            ErrorCode errorCode,
+            String message
+    ) {
+        super(errorCode.changeMessage(message).getMessage());
+        this.errorCode = errorCode.changeMessage(message);
+    }
+
+    public CustomException(
+            ErrorCode errorCode,
+            ErrorData errorData
+    ) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
         this.errorData = errorData;

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -9,21 +9,30 @@ public enum ErrorCode {
 
     SUCCESS(HttpStatus.OK, "200", "OK"),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "404", "회원를 찾을 수 없습니다"),
-    INVALID_FORMAT(HttpStatus.BAD_REQUEST, "400", "데이터를 검증 실패");
+    INVALID_FORMAT(HttpStatus.BAD_REQUEST, "400", "데이터 검증 실패"),
+    AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "인증에 실패 했습니다"),
+    EMAIL_AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "이메일 인증에 실패 했습니다");
 
     @JsonIgnore
     private final HttpStatus statusCode;
     private final String code;
     private String message;
 
-    ErrorCode(HttpStatus statusCode, String code, String message) {
+    ErrorCode(
+            HttpStatus statusCode,
+            String code,
+            String message
+    ) {
         this.statusCode = statusCode;
         this.code = code;
         this.message = message;
     }
 
-    public ErrorCode changeMessage(String message) {
+    public ErrorCode changeMessage(
+            String message
+    ) {
         this.message = message;
         return this;
     }
+
 }

--- a/back/src/main/java/com/ogjg/back/config/security/config/JwtTokenConfig.java
+++ b/back/src/main/java/com/ogjg/back/config/security/config/JwtTokenConfig.java
@@ -1,0 +1,34 @@
+package com.ogjg.back.config.security.config;
+
+import com.ogjg.back.config.security.jwt.JwtTokenClaims;
+import com.ogjg.back.user.dto.request.JwtEmailAuthClaimsDto;
+import com.ogjg.back.user.dto.request.JwtUserClaimsDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Configuration
+@RequiredArgsConstructor
+public class JwtTokenConfig {
+
+
+    @Bean
+    public JwtTokenClaims jwtUserClaimsDto() {
+        return new JwtUserClaimsDto();
+    }
+
+    @Bean
+    public JwtTokenClaims jwtEmailAuthClaims() {
+        return new JwtEmailAuthClaimsDto();
+    }
+
+    @Bean
+    public Map<String, SseEmitter> clients() {
+        return new ConcurrentHashMap<>();
+    }
+
+}

--- a/back/src/main/java/com/ogjg/back/config/security/config/JwtTokenConfig.java
+++ b/back/src/main/java/com/ogjg/back/config/security/config/JwtTokenConfig.java
@@ -6,6 +6,7 @@ import com.ogjg.back.user.dto.request.JwtUserClaimsDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.annotation.RequestScope;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.Map;
@@ -17,11 +18,13 @@ public class JwtTokenConfig {
 
 
     @Bean
+    @RequestScope
     public JwtTokenClaims jwtUserClaimsDto() {
         return new JwtUserClaimsDto();
     }
 
     @Bean
+    @RequestScope
     public JwtTokenClaims jwtEmailAuthClaims() {
         return new JwtEmailAuthClaimsDto();
     }

--- a/back/src/main/java/com/ogjg/back/config/security/config/SecurityConfig.java
+++ b/back/src/main/java/com/ogjg/back/config/security/config/SecurityConfig.java
@@ -9,10 +9,7 @@ import com.ogjg.back.user.service.EmailAuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -35,8 +32,10 @@ public class SecurityConfig {
 
 
     private final List<String> permitUrlList = new ArrayList<>(
-            List.of("/api/user/email-auth/.*",
-                    "/signup"
+            List.of("/api/users/email-auth/.*",
+                    "/signup",
+                    "health",
+                    "/test"
             ));
 
 
@@ -58,31 +57,13 @@ public class SecurityConfig {
     }
 
     @Bean
-    @Primary
-    public AuthenticationManager authenticationManager(
-            AuthenticationConfiguration authenticationConfiguration
-    ) throws Exception {
-        return authenticationConfiguration.getAuthenticationManager();
-    }
-
-    @Bean
-    public AuthenticationManager emailAuthenticationManager() throws Exception {
-        return new ProviderManager(Collections.singletonList(emailAuthenticationProvider()));
-    }
-
-    @Bean
-    public AuthenticationManager jwtAuthenticationManager() throws Exception {
-        return new ProviderManager(Collections.singletonList(jwtAuthenticationProvider()));
-    }
-
-    @Bean
     public EmailAuthenticationFilter emailAuthenticationFilter() throws Exception {
-        return new EmailAuthenticationFilter(emailAuthenticationManager(), emailAuthService);
+        return new EmailAuthenticationFilter(new ProviderManager(Collections.singletonList(emailAuthenticationProvider())), emailAuthService);
     }
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
-        return new JwtAuthenticationFilter(jwtAuthenticationManager(), permitUrlList);
+        return new JwtAuthenticationFilter(new ProviderManager(Collections.singletonList(jwtAuthenticationProvider())), permitUrlList);
     }
 
     @Bean

--- a/back/src/main/java/com/ogjg/back/config/security/config/SecurityConfig.java
+++ b/back/src/main/java/com/ogjg/back/config/security/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
     private final List<String> permitUrlList = new ArrayList<>(
             List.of("/api/users/email-auth/.*",
                     "/signup",
-                    "health",
+                    "/health",
                     "/test"
             ));
 

--- a/back/src/main/java/com/ogjg/back/config/security/config/SecurityConfig.java
+++ b/back/src/main/java/com/ogjg/back/config/security/config/SecurityConfig.java
@@ -1,0 +1,98 @@
+package com.ogjg.back.config.security.config;
+
+import com.ogjg.back.config.security.emailauth.EmailAuthenticationFilter;
+import com.ogjg.back.config.security.emailauth.EmailAuthenticationProvider;
+import com.ogjg.back.config.security.jwt.JwtAuthenticationFilter;
+import com.ogjg.back.config.security.jwt.JwtAuthenticationProvider;
+import com.ogjg.back.config.security.jwt.JwtUtils;
+import com.ogjg.back.user.service.EmailAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableWebSecurity(debug = true)
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final EmailAuthService emailAuthService;
+    private final JwtUtils jwtUtils;
+
+
+    private final List<String> permitUrlList = new ArrayList<>(
+            List.of("/api/user/email-auth/.*",
+                    "/signup"
+            ));
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(
+            HttpSecurity http
+    ) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
+                .addFilterBefore(
+                        emailAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class
+                )
+                .authorizeHttpRequests(
+                        authorize -> authorize
+                                .anyRequest().permitAll())
+                .csrf(AbstractHttpConfigurer::disable)
+                .build();
+    }
+
+    @Bean
+    @Primary
+    public AuthenticationManager authenticationManager(
+            AuthenticationConfiguration authenticationConfiguration
+    ) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public AuthenticationManager emailAuthenticationManager() throws Exception {
+        return new ProviderManager(Collections.singletonList(emailAuthenticationProvider()));
+    }
+
+    @Bean
+    public AuthenticationManager jwtAuthenticationManager() throws Exception {
+        return new ProviderManager(Collections.singletonList(jwtAuthenticationProvider()));
+    }
+
+    @Bean
+    public EmailAuthenticationFilter emailAuthenticationFilter() throws Exception {
+        return new EmailAuthenticationFilter(emailAuthenticationManager(), emailAuthService);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        return new JwtAuthenticationFilter(jwtAuthenticationManager(), permitUrlList);
+    }
+
+    @Bean
+    public JwtAuthenticationProvider jwtAuthenticationProvider() {
+        return new JwtAuthenticationProvider(jwtUtils);
+    }
+
+    @Bean
+    public EmailAuthenticationProvider emailAuthenticationProvider() {
+        return new EmailAuthenticationProvider(jwtUtils);
+    }
+
+}

--- a/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthUserDetails.java
+++ b/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthUserDetails.java
@@ -1,0 +1,53 @@
+package com.ogjg.back.config.security.emailauth;
+
+import com.ogjg.back.user.dto.request.JwtEmailAuthClaimsDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class EmailAuthUserDetails implements UserDetails {
+
+    private final JwtEmailAuthClaimsDto jwtEmailAuthClaimsDto;
+
+    public String getEmail() {
+        return jwtEmailAuthClaimsDto.getEmail();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthenticationFilter.java
+++ b/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthenticationFilter.java
@@ -1,0 +1,72 @@
+package com.ogjg.back.config.security.emailauth;
+
+import com.ogjg.back.user.service.EmailAuthService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+public class EmailAuthenticationFilter extends OncePerRequestFilter {
+
+
+    private final AuthenticationManager authenticationManager;
+    private final EmailAuthService emailAuthService;
+
+    public EmailAuthenticationFilter(
+            @Qualifier("emailAuthenticationManager") AuthenticationManager authenticationManager,
+            EmailAuthService emailAuthService
+    ) {
+        this.authenticationManager = authenticationManager;
+        this.emailAuthService = emailAuthService;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String uri = request.getRequestURI();
+
+        if (uri.startsWith("/favicon")) {
+//            todo favicon 어떻게 처리할지 고민해보기
+            return;
+        }
+
+        if (!uri.startsWith("/api/user/email-auth/success/")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        Authentication authenticate = null;
+        try {
+
+            String token = uri.substring("/api/user/email-auth/success/".length());
+            EmailAuthenticationToken emailAuthenticationToken = new EmailAuthenticationToken(token);
+
+            authenticate = authenticationManager.authenticate(emailAuthenticationToken);
+
+        } catch (Exception e) {
+            log.error("이메일 인증도중 에러발생 = {}", e.getMessage());
+        }
+
+        EmailAuthUserDetails principal = (EmailAuthUserDetails) authenticate.getPrincipal();
+
+        emailAuthService.successEmailAuth(principal);
+
+        String emailSuccessTemplate = emailAuthService.emailAuthTemplate("email_auth_success.html");
+        response.setContentType("text/html; charset=UTF-8");
+        response.getWriter().write(emailSuccessTemplate);
+    }
+}
+
+

--- a/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthenticationFilter.java
+++ b/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthenticationFilter.java
@@ -42,7 +42,7 @@ public class EmailAuthenticationFilter extends OncePerRequestFilter {
             return;
         }
 
-        if (!uri.startsWith("/api/user/email-auth/success/")) {
+        if (!uri.startsWith("/api/users/email-auth/success/")) {
             filterChain.doFilter(request, response);
             return;
         }
@@ -50,7 +50,7 @@ public class EmailAuthenticationFilter extends OncePerRequestFilter {
         Authentication authenticate = null;
         try {
 
-            String token = uri.substring("/api/user/email-auth/success/".length());
+            String token = uri.substring("/api/users/email-auth/success/".length());
             EmailAuthenticationToken emailAuthenticationToken = new EmailAuthenticationToken(token);
 
             authenticate = authenticationManager.authenticate(emailAuthenticationToken);

--- a/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthenticationProvider.java
+++ b/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthenticationProvider.java
@@ -1,0 +1,49 @@
+package com.ogjg.back.config.security.emailauth;
+
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.config.security.exception.EmailAuthFailure;
+import com.ogjg.back.config.security.jwt.JwtUtils;
+import com.ogjg.back.user.dto.request.JwtEmailAuthClaimsDto;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class EmailAuthenticationProvider implements AuthenticationProvider {
+
+    private final JwtUtils jwtUtils;
+
+    @Override
+    public Authentication authenticate(
+            Authentication authentication
+    ) throws AuthenticationException {
+        String jwt = String.valueOf(authentication.getCredentials());
+
+        if (!jwtUtils.isValidToken(jwt)) {
+            throw new EmailAuthFailure();
+        }
+
+        EmailAuthUserDetails emailAuthUserDetails = emailAuthUserDetails(jwt);
+
+        return new EmailAuthenticationToken(emailAuthUserDetails, jwt, Collections.emptyList());
+    }
+
+    private EmailAuthUserDetails emailAuthUserDetails(String jwt) {
+        Claims claims = jwtUtils.getClaims(jwt);
+
+        JwtEmailAuthClaimsDto emailAuthClaimsDto = JwtEmailAuthClaimsDto.builder()
+                .email(String.valueOf(claims.get("email")))
+                .build();
+
+        return new EmailAuthUserDetails(emailAuthClaimsDto);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(EmailAuthenticationToken.class);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthenticationToken.java
+++ b/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthenticationToken.java
@@ -1,0 +1,42 @@
+package com.ogjg.back.config.security.emailauth;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public class EmailAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final UserDetails principal;
+    private String jwt;
+
+    public EmailAuthenticationToken(
+            String jwt) {
+        super(null);
+        this.principal = null;
+        this.jwt = jwt;
+        setAuthenticated(false);
+    }
+
+    public EmailAuthenticationToken(
+            UserDetails principal,
+            String jwt,
+            Collection<? extends GrantedAuthority> authorities
+    ) {
+        super(authorities);
+        this.principal = principal;
+        this.jwt = jwt;
+        super.setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return jwt;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/config/security/exception/EmailAuthFailure.java
+++ b/back/src/main/java/com/ogjg/back/config/security/exception/EmailAuthFailure.java
@@ -1,0 +1,24 @@
+package com.ogjg.back.config.security.exception;
+
+import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorData;
+
+public class EmailAuthFailure extends CustomException {
+
+    public EmailAuthFailure() {
+        super(ErrorCode.EMAIL_AUTH_FAIL);
+    }
+
+    public EmailAuthFailure(
+            String message
+    ) {
+        super(ErrorCode.EMAIL_AUTH_FAIL, message);
+    }
+
+    public EmailAuthFailure(
+            ErrorData errorData
+    ) {
+        super(ErrorCode.EMAIL_AUTH_FAIL, errorData);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/config/security/exception/JwtAuthFailure.java
+++ b/back/src/main/java/com/ogjg/back/config/security/exception/JwtAuthFailure.java
@@ -1,0 +1,25 @@
+package com.ogjg.back.config.security.exception;
+
+import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorData;
+
+public class JwtAuthFailure extends CustomException {
+
+    public JwtAuthFailure() {
+        super(ErrorCode.AUTH_FAIL);
+    }
+
+    public JwtAuthFailure(
+            String message
+    ) {
+        super(ErrorCode.AUTH_FAIL, message);
+    }
+
+    public JwtAuthFailure(
+            ErrorData errorData
+    ) {
+        super(ErrorCode.AUTH_FAIL, errorData);
+    }
+
+}

--- a/back/src/main/java/com/ogjg/back/config/security/jwt/JwtAuthenticationFilter.java
+++ b/back/src/main/java/com/ogjg/back/config/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,83 @@
+package com.ogjg.back.config.security.jwt;
+
+import com.ogjg.back.config.security.exception.JwtAuthFailure;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final AuthenticationManager authenticationManager;
+    private final List<String> permitUrlList;
+
+
+    public JwtAuthenticationFilter(
+            @Qualifier("jwtAuthenticationManager") AuthenticationManager authenticationManager,
+            List<String> permitUrlList
+    ) {
+        this.authenticationManager = authenticationManager;
+        this.permitUrlList = permitUrlList;
+    }
+
+    private final String PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        if (isPermitted(request.getRequestURI())) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            String jwt = getJwt(request);
+            JwtAuthenticationToken jwtAuthenticationToken = new JwtAuthenticationToken(jwt);
+
+            Authentication authenticate = authenticationManager.authenticate(jwtAuthenticationToken);
+
+            SecurityContextHolder.getContext().setAuthentication(authenticate);
+        } catch (Exception e) {
+            throw new JwtAuthFailure();
+        }
+    }
+
+    /*
+     * 허용된 URL 인지 확인하기
+     * */
+    private boolean isPermitted(String requestUri) {
+        for (String pattern : permitUrlList) {
+            if (Pattern.matches(pattern, requestUri)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /*
+     * 헤더에서 토큰값 가져오기
+     * */
+    private String getJwt(HttpServletRequest request) {
+        String jwt = request.getHeader("Authorization");
+
+        if (jwt != null && jwt.startsWith(PREFIX)) {
+            return jwt.substring(PREFIX.length());
+        }
+
+        throw new JwtAuthFailure("유효하지 않은 JWT 입니다.");
+    }
+}

--- a/back/src/main/java/com/ogjg/back/config/security/jwt/JwtAuthenticationProvider.java
+++ b/back/src/main/java/com/ogjg/back/config/security/jwt/JwtAuthenticationProvider.java
@@ -1,0 +1,46 @@
+package com.ogjg.back.config.security.jwt;
+
+import com.ogjg.back.config.security.exception.JwtAuthFailure;
+import com.ogjg.back.user.dto.request.JwtUserClaimsDto;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+import java.util.Collections;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+    private final JwtUtils jwtUtils;
+
+    @Override
+    public Authentication authenticate(
+            Authentication authentication
+    ) throws AuthenticationException {
+        String jwt = String.valueOf(authentication.getCredentials());
+
+        if (!jwtUtils.isValidToken(jwt)) {
+            throw new JwtAuthFailure();
+        }
+        JwtUserDetails jwtUserDetails = getJwtUserDetails(jwt);
+
+        return new JwtAuthenticationToken(jwtUserDetails, jwt, Collections.emptyList());
+    }
+
+    private JwtUserDetails getJwtUserDetails(String jwt) {
+        Claims claims = jwtUtils.getClaims(jwt);
+
+        JwtUserClaimsDto userClaimsDto = JwtUserClaimsDto.builder()
+                .email((String) claims.get("email"))
+                .build();
+
+        return new JwtUserDetails(userClaimsDto);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return authentication.equals(JwtAuthenticationToken.class);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/config/security/jwt/JwtAuthenticationToken.java
+++ b/back/src/main/java/com/ogjg/back/config/security/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,42 @@
+package com.ogjg.back.config.security.jwt;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final UserDetails principal;
+    private String jwt;
+
+    public JwtAuthenticationToken(
+            String jwt) {
+        super(null);
+        this.principal = null;
+        this.jwt = jwt;
+        setAuthenticated(false);
+    }
+
+    public JwtAuthenticationToken(
+            UserDetails principal,
+            String jwt,
+            Collection<? extends GrantedAuthority> authorities
+    ) {
+        super(authorities);
+        this.principal = principal;
+        this.jwt = jwt;
+        super.setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return jwt;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/config/security/jwt/JwtTokenClaims.java
+++ b/back/src/main/java/com/ogjg/back/config/security/jwt/JwtTokenClaims.java
@@ -1,0 +1,12 @@
+package com.ogjg.back.config.security.jwt;
+
+import lombok.Setter;
+
+@Setter
+public abstract class JwtTokenClaims {
+
+    private String email;
+
+    public abstract String getEmail();
+
+}

--- a/back/src/main/java/com/ogjg/back/config/security/jwt/JwtUserDetails.java
+++ b/back/src/main/java/com/ogjg/back/config/security/jwt/JwtUserDetails.java
@@ -1,0 +1,57 @@
+package com.ogjg.back.config.security.jwt;
+
+import com.ogjg.back.user.dto.request.JwtUserClaimsDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@RequiredArgsConstructor
+public class JwtUserDetails implements UserDetails {
+
+    private final JwtUserClaimsDto jwtUserClaimsDto;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    public String getEmail() {
+        return jwtUserClaimsDto.getEmail();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    //계정의 만료여부
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    //계정이 잠겨있는지 확인
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    //인증 자격 만료 여부 확인
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    //계정의 활성화 여부
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/config/security/jwt/JwtUtils.java
+++ b/back/src/main/java/com/ogjg/back/config/security/jwt/JwtUtils.java
@@ -1,0 +1,139 @@
+package com.ogjg.back.config.security.jwt;
+
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.config.security.exception.JwtAuthFailure;
+import io.jsonwebtoken.*;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class JwtUtils {
+
+    private final static long ACCESS_TOKEN_VALID_TIME = 5 * 60 * 1000;
+    private final static long REFRESH_TOKEN_VALID_TIME = 14 * 24 * 60 * 60 * 1000;
+    private final static long EMAIL_TOKEN_VALID_TIME = 3 * 60 * 1000;
+    private final static String ISSUER = "team_ogjg_Web_IDE";
+    private static Key SIGNATURE_KEY;
+
+    /*
+     * 토큰 key 초기화
+     * */
+    public JwtUtils(
+            @Value("${jwt.secret}") String jwtSecret
+    ) {
+        byte[] byteSecretKey = jwtSecret.getBytes(StandardCharsets.UTF_8);
+        SIGNATURE_KEY = new SecretKeySpec(byteSecretKey, SignatureAlgorithm.HS256.getJcaName());
+    }
+
+    /*
+     * accessToken 생성
+     * */
+    public String generateAccessToken(
+            @Qualifier("jwtUserClaimsDto") JwtTokenClaims userClaimsDto
+    ) {
+        return Jwts.builder()
+                .setHeader(createHeader())
+                .setClaims(createClaims(userClaimsDto))
+                .setExpiration(new Date(System.currentTimeMillis() + ACCESS_TOKEN_VALID_TIME))
+                .signWith(SIGNATURE_KEY)
+                .compact();
+    }
+
+    /*
+     * refreshToken 생성
+     * */
+    public String generateRefreshToken(
+            @Qualifier("jwtUserClaimsDto") JwtTokenClaims userClaimsDto
+    ) {
+        return Jwts.builder()
+                .setHeader(createHeader())
+                .setClaims(createClaims(userClaimsDto))
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_VALID_TIME))
+                .signWith(SIGNATURE_KEY)
+                .compact();
+    }
+
+    /*
+     * emailAuthToken 생성
+     * */
+    public String generateEmailAuthToken(
+            @Qualifier("jwtEmailAuthClaims") JwtTokenClaims emailAuthClaimsDto
+    ) {
+        return Jwts.builder()
+                .setHeader(createHeader())
+                .setClaims(createClaims(emailAuthClaimsDto))
+                .setExpiration(new Date(System.currentTimeMillis() + EMAIL_TOKEN_VALID_TIME))
+                .signWith(SIGNATURE_KEY)
+                .compact();
+    }
+
+    /*
+     * 토큰 검증
+     * */
+    public boolean isValidToken(
+            String jwt
+    ) {
+
+        Claims claims = getClaims(jwt);
+
+        if (!ISSUER.equals(claims.get("iss"))) {
+            throw new JwtAuthFailure("Issuer가 일치하지 않습니다.");
+        }
+
+        Date expiration = claims.getExpiration();
+        if (expiration.before(new Date())) {
+            throw new JwtAuthFailure("토큰이 만료되었습니다.");
+        }
+
+        return true;
+    }
+
+    /*
+     * 토큰 파싱, 검증
+     * 주어진 token을 파싱하고,
+     * 그 결과를 Jws<Claims> 객체로 반환합니다.
+     * 이 과정에서 서명도 검증됩니다.
+     * 만약 서명이 유효하지 않다면 예외가 발생합니다.
+     * */
+    public Claims getClaims(
+            String token
+    ) {
+        Jws<Claims> claimsJws = Jwts.parserBuilder()
+                .setSigningKey(SIGNATURE_KEY)
+                .build()
+                .parseClaimsJws(token);
+
+        return claimsJws.getBody();
+    }
+
+    /*
+     * 토큰의 헤더
+     * */
+    private Map<String, Object> createHeader() {
+        return new HashMap<>(Map.of(
+                "alg", "HS256",
+                "typ", "JWT"
+        ));
+    }
+
+    /*
+     * 토큰안에 들어갈 내용
+     * */
+    private Map<String, Object> createClaims(
+            JwtTokenClaims jwtTokenClaims
+    ) {
+        return new HashMap<>(Map.of(
+                "iss", ISSUER,
+                "email", jwtTokenClaims.getEmail()
+        ));
+    }
+
+}

--- a/back/src/main/java/com/ogjg/back/user/controller/UserController.java
+++ b/back/src/main/java/com/ogjg/back/user/controller/UserController.java
@@ -2,27 +2,53 @@ package com.ogjg.back.user.controller;
 
 import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.response.ApiResponse;
+import com.ogjg.back.user.dto.request.EmailAuthRequest;
 import com.ogjg.back.user.dto.request.InfoUpdateRequest;
 import com.ogjg.back.user.dto.request.PasswordUpdateRequest;
+import com.ogjg.back.user.dto.request.UserRequest;
 import com.ogjg.back.user.dto.response.ImgUpdateResponse;
+import com.ogjg.back.user.service.EmailAuthService;
 import com.ogjg.back.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
+import java.util.Map;
+
+@Slf4j
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("api/users")
 public class UserController {
 
+    private final EmailAuthService emailAuthService;
     private final UserService userService;
+    private final Map<String, SseEmitter> clients;
+    public static final long EMAIL_TIMEOUT = 3 * 60 * 1000L;
+
+    /*
+     * 회원가입
+     * */
+    @PostMapping("/signup")
+    public ApiResponse<?> signup(
+            @RequestBody @Valid UserRequest userRequest
+    ) {
+        userService.signUp(userRequest);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
 
     // todo : update 로직 응답 값 정의 및 추가 필요, 토큰 추가 시 email 정보 추가
     /**
      * 프로필 사진 업로드(변경 시 덮어씀)
      */
     @PatchMapping("/img")
-    public ApiResponse<ImgUpdateResponse> updateImg(@RequestParam("img") MultipartFile imgFile) {
+    public ApiResponse<ImgUpdateResponse> updateImg(
+            @RequestParam("img") MultipartFile imgFile
+    ) {
         String loginEmail = "ogjg1234@naver.com";
 
         return new ApiResponse<>(
@@ -35,7 +61,9 @@ public class UserController {
      * 회원 정보 변경
      */
     @PatchMapping("/info")
-    public ApiResponse<Void> updateInfo(@RequestBody InfoUpdateRequest request) {
+    public ApiResponse<Void> updateInfo(
+            @RequestBody InfoUpdateRequest request
+    ) {
         String loginEmail = "ogjg1234@naver.com";
 
         userService.updateInfo(request, loginEmail);
@@ -46,7 +74,9 @@ public class UserController {
      * 회원 비밀번호 변경
      */
     @PatchMapping("/password")
-    public ApiResponse<Void> updatePassword(@RequestBody PasswordUpdateRequest request) {
+    public ApiResponse<Void> updatePassword(
+            @RequestBody PasswordUpdateRequest request
+    ) {
         String loginEmail = "ogjg1234@naver.com";
 
         userService.updatePassword(request, loginEmail);
@@ -62,5 +92,38 @@ public class UserController {
 
         userService.deactivate(loginEmail);
         return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
+    /*
+     * emitter 연결유지
+     * 이메일 인증메일 보내기
+     * */
+    @PostMapping("/email-auth/{clientId}")
+    public SseEmitter emailAuth(
+            @PathVariable(name = "clientId") String clientId,
+            @RequestBody @Valid EmailAuthRequest emailAuthRequest
+    ) {
+        SseEmitter emitter = new SseEmitter(EMAIL_TIMEOUT);
+
+        emitter.onTimeout(() -> {
+            emailAuthService.completeEmitter(emitter);
+            emailAuthService.removeClient(clientId);
+        });
+
+        clients.put(clientId, emitter);
+        emailAuthService.emailAuth(emailAuthRequest, clientId);
+
+        ApiResponse<?> apiResponse = new ApiResponse<>(
+                ErrorCode.SUCCESS
+                        .changeMessage("인증 메일이 전송되었습니다, 인증 확인 버튼을 눌러주세요")
+        );
+
+        try {
+            emitter.send(SseEmitter.event().data(apiResponse));
+        } catch (IOException e) {
+            log.error("인증 메일 메시지 전송에 실패했습니다");
+        }
+
+        return emitter;
     }
 }

--- a/back/src/main/java/com/ogjg/back/user/dto/request/JwtEmailAuthClaimsDto.java
+++ b/back/src/main/java/com/ogjg/back/user/dto/request/JwtEmailAuthClaimsDto.java
@@ -1,0 +1,17 @@
+package com.ogjg.back.user.dto.request;
+
+import com.ogjg.back.config.security.jwt.JwtTokenClaims;
+import lombok.*;
+
+
+@Getter
+@NoArgsConstructor
+public class JwtEmailAuthClaimsDto extends JwtTokenClaims {
+
+    private String email;
+
+    @Builder
+    public JwtEmailAuthClaimsDto(String email) {
+        this.email = email;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/user/dto/request/JwtUserClaimsDto.java
+++ b/back/src/main/java/com/ogjg/back/user/dto/request/JwtUserClaimsDto.java
@@ -1,0 +1,17 @@
+package com.ogjg.back.user.dto.request;
+
+import com.ogjg.back.config.security.jwt.JwtTokenClaims;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+public class JwtUserClaimsDto extends JwtTokenClaims {
+
+    private String email;
+
+    @Builder
+    public JwtUserClaimsDto(String email) {
+        this.email = email;
+    }
+}
+

--- a/back/src/main/java/com/ogjg/back/user/exception/NotFoundUser.java
+++ b/back/src/main/java/com/ogjg/back/user/exception/NotFoundUser.java
@@ -10,7 +10,15 @@ public class NotFoundUser extends CustomException {
         super(ErrorCode.NOT_FOUND_USER);
     }
 
-    public NotFoundUser(ErrorData errorData) {
+    public NotFoundUser(
+            String message
+    ) {
+        super(ErrorCode.NOT_FOUND_USER, message);
+    }
+
+    public NotFoundUser(
+            ErrorData errorData
+    ) {
         super(ErrorCode.NOT_FOUND_USER, errorData);
     }
 }

--- a/back/src/main/java/com/ogjg/back/user/repository/EmailAuthRepository.java
+++ b/back/src/main/java/com/ogjg/back/user/repository/EmailAuthRepository.java
@@ -1,0 +1,12 @@
+package com.ogjg.back.user.repository;
+
+import com.ogjg.back.user.domain.EmailAuth;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
+
+    Optional<EmailAuth> findByEmail(String email);
+
+}

--- a/back/src/main/java/com/ogjg/back/user/service/EmailAuthService.java
+++ b/back/src/main/java/com/ogjg/back/user/service/EmailAuthService.java
@@ -1,0 +1,188 @@
+package com.ogjg.back.user.service;
+
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.response.ApiResponse;
+import com.ogjg.back.config.security.emailauth.EmailAuthUserDetails;
+import com.ogjg.back.config.security.jwt.JwtUtils;
+import com.ogjg.back.user.domain.EmailAuth;
+import com.ogjg.back.user.dto.EmailAuthSaveDto;
+import com.ogjg.back.user.dto.request.EmailAuthRequest;
+import com.ogjg.back.user.dto.request.JwtEmailAuthClaimsDto;
+import com.ogjg.back.user.repository.EmailAuthRepository;
+import com.ogjg.back.user.repository.UserRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class EmailAuthService {
+
+    private final EmailAuthRepository emailAuthRepository;
+    private final UserRepository userRepository;
+    private final JavaMailSender mailSender;
+    private final JwtUtils jwtUtils;
+    private final Map<String, SseEmitter> clients;
+    private static final String EMAIL_AUTH_ADDRESS = "http://localhost:8080/api/user/email-auth/success";
+
+    /*
+     * 이메일 중복 체크 후 인증관련 데이터 저장 후 인증 메일 발송
+     * */
+    @Transactional
+    public void emailAuth(EmailAuthRequest emailAuthRequest, String clientId) {
+
+        if (userRepository.findByEmail(emailAuthRequest.getEmail()).isPresent())
+            throw new IllegalArgumentException("이미 가입된 이메일 입니다.");
+
+        EmailAuth emailAuth = saveEmailAuth(emailAuthRequest, clientId);
+
+        sendEmailAuth(emailAuthRequest.getEmail(), emailAuth.getEmailToken());
+    }
+
+    /*
+     * 이메일 인증 데이터 저장후 반환
+     * 이미 인증기록이 존재하면 삭제후 다시 생성
+     * 삭제가 아니라 업데이트를 사용한다면 성능개선 가능
+     * */
+    private EmailAuth saveEmailAuth(EmailAuthRequest emailAuthRequest, String clientId) {
+
+        if (emailAuthRepository.findByEmail(emailAuthRequest.getEmail()).isPresent())
+            emailAuthRepository.delete(findEmailAuthByEmail(emailAuthRequest.getEmail()));
+
+        EmailAuthSaveDto emailAuthSaveDto = new EmailAuthSaveDto(emailAuthRequest.getEmail(), clientId);
+        emailAuthRepository.save(new EmailAuth(emailAuthSaveDto));
+
+        EmailAuth emailAuth = findEmailAuthByEmail(emailAuthRequest.getEmail());
+
+        String emailAuthToken = createEmailAuthToken(emailAuth);
+        emailAuth.inPutEmailToken(emailAuthToken);
+
+        return emailAuth;
+    }
+
+    /*
+     * 회원가입 이메일로 EmailAuth 데이터 찾기
+     * */
+    private EmailAuth findEmailAuthByEmail(String email) {
+        return emailAuthRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("인증을 위한 이메일을 찾을 수 없습니다"));
+    }
+
+    /*
+     * 회원가입 이메일 인증 토큰 생성
+     * */
+    private String createEmailAuthToken(EmailAuth emailAuth) {
+        JwtEmailAuthClaimsDto emailAuthClaim = JwtEmailAuthClaimsDto.builder()
+                .email(emailAuth.getEmail())
+                .build();
+
+        return jwtUtils.generateEmailAuthToken(emailAuthClaim);
+    }
+
+
+    /*
+     * 회원가입 이메일 인증메일 발송
+     * */
+    private void sendEmailAuth(String email, String emailAuthToken) {
+        try {
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "utf-8");
+
+            String htmlContent = emailAuthTemplate("email_template.html");
+            htmlContent = htmlContent.replace("project_url_address_here", EMAIL_AUTH_ADDRESS);
+            htmlContent = htmlContent.replace("unique_token_here", emailAuthToken);
+
+            helper.setTo(email);
+            helper.setSubject("이메일 인증");
+            helper.setText(htmlContent, true);
+
+            mailSender.send(mimeMessage);
+        } catch (MessagingException e) {
+            throw new IllegalArgumentException("인증 이메일을 발송하는데 오류가 발생했습니다");
+        }
+    }
+
+    /*
+     * 회원가입 이메일 인증 UI 읽어오기
+     * */
+    public String emailAuthTemplate(String emailTemplate) {
+        try {
+            ClassPathResource resource = new ClassPathResource(emailTemplate);
+            byte[] encoded = Files.readAllBytes(Paths.get(resource.getURI()));
+            return new String(encoded, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("이메일 인증 템플릿을 불러올 수 없습니다");
+        }
+    }
+
+    /*
+     * emitter 연결 끊기
+     * */
+    public void completeEmitter(SseEmitter emitter) {
+        try {
+            emitter.complete();
+        } catch (Exception e) {
+            log.error("emitter를 닫는데 실패했습니다" + e.getMessage(), e);
+        }
+    }
+
+    /*
+     * emitter 연결 정보 제거
+     * */
+    public void removeClient(String clientId) {
+        try {
+            clients.remove(clientId);
+        } catch (Exception e) {
+            log.error("clients를 제거하는데 실패했습니다" + e.getMessage(), e);
+        }
+    }
+
+    /*
+     * 이메일 인증이 완료되면
+     * 토큰에서 들어온 Email 기준으로 DB 조회 후
+     * 인증상태, 인증시간 을 저장
+     * */
+    @Transactional
+    public void successEmailAuth(EmailAuthUserDetails principal) {
+        EmailAuth emailAuth = findEmailAuthByEmail(principal.getEmail());
+        emailAuth.completeEmailAuth();
+        emailAuth.completeEmailAuthTime();
+
+        SseEmitter emitter = clients.get(emailAuth.getClient_id());
+
+        successEmailResponse(emailAuth, emitter);
+    }
+
+    /*
+     * 이메일 인증 성공 메시지
+     * 클라이언트에 반환 후 Emitter 연결 종료
+     * */
+    private void successEmailResponse(EmailAuth emailAuth, SseEmitter emitter) {
+        if (emitter != null) {
+            try {
+                emitter.send(
+                        new ApiResponse<>(ErrorCode.SUCCESS.changeMessage("인증이 완료되었습니다"))
+                );
+            } catch (IOException e) {
+                log.error("인증완료 메시지를 보내는데 실패했습니다" + e.getMessage());
+            } finally {
+                completeEmitter(emitter);
+                removeClient(emailAuth.getClient_id());
+            }
+        }
+    }
+}

--- a/back/src/main/java/com/ogjg/back/user/service/EmailAuthService.java
+++ b/back/src/main/java/com/ogjg/back/user/service/EmailAuthService.java
@@ -37,7 +37,7 @@ public class EmailAuthService {
     private final JavaMailSender mailSender;
     private final JwtUtils jwtUtils;
     private final Map<String, SseEmitter> clients;
-    private static final String EMAIL_AUTH_ADDRESS = "http://localhost:8080/api/user/email-auth/success";
+    private static final String EMAIL_AUTH_ADDRESS = "http://localhost:8080/api/users/email-auth/success";
 
     /*
      * 이메일 중복 체크 후 인증관련 데이터 저장 후 인증 메일 발송

--- a/back/src/main/java/com/ogjg/back/user/service/UserService.java
+++ b/back/src/main/java/com/ogjg/back/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.ogjg.back.user.service;
 import com.ogjg.back.user.domain.User;
 import com.ogjg.back.user.dto.request.InfoUpdateRequest;
 import com.ogjg.back.user.dto.request.PasswordUpdateRequest;
+import com.ogjg.back.user.dto.request.UserRequest;
 import com.ogjg.back.user.dto.response.ImgUpdateResponse;
 import com.ogjg.back.user.exception.NotFoundUser;
 import com.ogjg.back.user.repository.UserRepository;
@@ -23,7 +24,7 @@ public class UserService {
 
         // todo : 이미지 데이터 aws 업로드 로직 추가
         // S3에 파일 데이터 저장 후, 경로 반환
-        String aws_url = "temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/" +findUser.getEmail()+"/{fileName}";
+        String aws_url = "temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/" + findUser.getEmail() + "/{fileName}";
 
         User user = findUser.updateImg(aws_url);
         return ImgUpdateResponse.of(user);
@@ -47,9 +48,15 @@ public class UserService {
         findUser.deactivate();
     }
 
-    @Transactional(readOnly = true)
     protected User findByEmail(String email) {
         return userRepository.findByEmail(email)
-                .orElseThrow(() -> new NotFoundUser());
+                .orElseThrow(NotFoundUser::new);
+    }
+
+    /*
+     * 회원가입
+     * */
+    public void signUp(UserRequest userRequest) {
+        userRepository.save(new User(userRequest));
     }
 }

--- a/back/src/main/resources/email_auth_success.html
+++ b/back/src/main/resources/email_auth_success.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>이메일 인증</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+            background-color: #f2f2f2;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+        }
+        .container {
+            width: 100%;
+            max-width: 400px;
+            background-color: #fff;
+            padding: 20px;
+            border-radius: 8px;
+            text-align: center;
+            box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+        }
+        .button {
+            display: inline-block;
+            padding: 12px 24px;
+            margin-top: 20px;
+            border-radius: 4px;
+            background-color: #007bff;
+            color: #ffffff;
+            text-decoration: none;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>[OGJG] <br> Web-IDE 이메일 인증이<br> 완료 되었습니다.</h1>
+    <p>기존 페이지로 돌아가서 <br> 회원가입을 완료해주세요</p>
+</div>
+</body>
+</html>

--- a/back/src/main/resources/email_template.html
+++ b/back/src/main/resources/email_template.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>이메일 인증</title>
+</head>
+<body style="font-family: Arial, sans-serif; margin: 0; padding: 0; background-color: #f2f2f2; display: flex; align-items: center; justify-content: center; height: 100vh;">
+<div style="width: 100%; height: 100%; display: flex; justify-content: center;  margin-top: 150px">
+    <div style="width: 100%; max-width: 400px; background-color: #fff; padding: 20px; border-radius: 8px; text-align: center; box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);">
+        <h1>[OGJG] <br> Web-IDE 이메일 인증입니다.</h1>
+        <p>회원가입을 완료하려면 <br> 아래의 "인증하기" 버튼을 클릭해 주세요.</p>
+        <a href="project_url_address_here/unique_token_here" style="display: inline-block; padding: 12px 24px; margin-top: 20px; border-radius: 4px; background-color: #007bff; color: #ffffff; text-decoration: none;">인증하기</a>
+    </div>
+</div>
+</body>
+</html>

--- a/back/src/test/java/com/ogjg/back/user/service/EmailAuthServiceTest.java
+++ b/back/src/test/java/com/ogjg/back/user/service/EmailAuthServiceTest.java
@@ -1,0 +1,21 @@
+package com.ogjg.back.user.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class EmailAuthServiceTest {
+
+    @Autowired
+    private EmailAuthService emailAuthService;
+
+
+
+    @Test
+    void userExceptionTest(){
+
+    }
+
+
+}


### PR DESCRIPTION
### **_Feat : OW-46 CustomException 기능추가, ErrorCode 추가_**
- CustomException ErrorMessage String 문자열으로 생성자에 입력하면 자동으로 변경되게 변경
- EmailAuth 관련 ErrorCode 추가

### **_Feat : spring-boot-mail 의존성 추가_**
- javaMailSender 사용위한 spring-boot-mail 의존성 추가

### **_Feat OW-47 : UserEmailAuth Service 기능 구현_**

> ### TokenClaims 생성

- [x] JwtTokenConfig : 상속받은 Claims bean 으로 등록하여 사용할 설정 파일
- [x] 토큰관련 인증이 들어올 때 토큰관련 정보를 받아올 JwtTokenClaims 생성 한가지 추상 클래스로 만들어줄 Claims 에서 상속 받아 bean 등록한 후 한가지 타입으로 사용하기 위함 의존성 구분은 @qualifier 를 사용해 구분할 예정
- [x] JwtTokenClaims : 부모 추상클래스로 타입을 유연하게 사용하게위해 생성
- [x] JwtEmailAuthClaimsDto : 유저관련 토큰을 파싱하여 정보를 담을 Dto
- [x] EmailAuthClaimsDto : 이메일 인증관련 토큰을 파싱하여 얻은 정보를 담을 Dto

> ### Exception 생성
- [x] 유저가 존재하지 않을시 발생시킬 NotFoundUser Exception 생성자를 통해 메시지를 변경할 수 있도록 변경

> ### UserService
- [x] 유저의 회원가입 로직 생성 -> 추후 변경 예정

> ### Email 인증 관련 template 추가
- [x] email_template.html : 이메일 인증메일 template
- [x] email_auth_success.html : 이메일 인증 성공시 반환시켜줄 html template

> ### EmailAuthService
- [x] emailAuth : 이미 가입한 사용자인지 확인 후 인증관련 데이터(SSE를 위한 clientId, 인증하는 이메일) 저장 후 인증 메일 발송
- [x] 이메일 인증시 과거에 인증절차를 거친 사용자면 기존 데이터 삭제 후 재 등록
- [x] 이메일 인증시 이메일 토큰 생성 후 이메일 인증 메일에 url+token 값을 가진 인증버튼 전송
- [x] 이메일을 인증하거나 인증시간이 만료되면 SSE 연결을 끊고 요청이 들어온 클라이언트의 주소 삭제
- [x] 이메일 인증이 완료되면 DB에서 인증상태와 인증시간을 변경
- [x] 이메일 성공시 성공 메시지 클라이언트에 반환 후 Emitter 연결 종료


### **_Feat OW-48 : EmailAuth Security Config 구현_**
> ### EmailAuthenticationFilter
- [x] 요청이 들어오면 SecurityConfig에서 EmailAuthenticationFilter 실행이 된다
- [x] 이메일 인증 요청인지 확인한 다음
이메일 인증 요청이라면 처리하고 아니라면 인증 절차가 실행되지 않는다
- [x] 요청에서 넘어온 토큰이 유효 하다면 토큰을 파싱하여 얻은 이메일을 통해 존재하는 요청인지 확인 후 요청이 들어온 이메일에 대해 인증상태와 인증시간을 변경 후 클라이언트에 인증 완료 응답을 보낸다

> ### EmailAuthenticationToken
- [x] EmailAuthenticationFilter 로 들어온 요청의 토큰을 EmailAuthenticationToken 객체 로 생성한 후 AuthenticationManager 에 넘긴다

> ### AuthenticationManager
- [x] AuthenticationManager 에서 EmailAuthenticationToken 객체를 어떤 인증방식으로 처리할건지 정한 후 EmailAuthenticationProvider 토큰을 넘겨준다

> ### EmailAuthenticationProvider
- [x] 인증을 처리한후 데이터를 파싱하여 eamilAuthUserDetails 안에 값을 넣는다

> ### EmailAuthFailure
- [x] 이메일 인증이 실패한다면 실행될 Exception

> ### EmailAuthenticationToken
- [x] 이메일 인증을 통해 들어온 토큰을 인증할때 사용할 토큰 객체

> ### EmailAuthUserDetails
- [x] 이메일 인증을 통해 토큰에 대한 유저 정보가 담길 객체


### **_Feat OW-50 : Jwt Security Config 구현_**
> ### JwtAuthenticationFilter
사용자 로그인에 대한 필터이다
- [x] 요청이 들어오면 SecurityConfig에서 AuthenticationFilter 로 요청이 들어와 토큰 인증을 거쳐야하는지 확인한다
- [x] 토큰 인증을 거쳐야하는 요청이라면 Filter가 실행된다
- [x] Header에서 토큰값을 가져와서 JwtAuthenticationToken 객체에 토큰값을 담아서 AuthenticationManager에게 어떤 방식으로 인증을 진행할지 넘긴다
- [x] 모든 인증처리가 완료되면 SecurityContextHolder안에 사용자에 대한 정보가 담기고 @AuthenticationPrincipal
 Annotaion을 통해 호출해서 사용할 수 있다

> ### jwtAuthenticationToken
- [x] jwtAuthenticationToken 로 들어온 요청의 토큰을 jwtAuthenticationToken 객체 로 생성한 후 AuthenticationManager 에 넘긴다

> ### AuthenticationManager
- [x] AuthenticationManager 에서 JwtAuthenticationToken 객체를 어떤 인증방식으로 처리할건지 정한 후 JwtAuthenticationProvider 토큰을 넘겨준다

> ### JwtAuthenticationProvider
- 인증을 처리한후 데이터를 파싱하여 JwtUserDetails 안에 값을 넣는다

> ### JwtAuthFailure
- 사용자 인증이 실패한다면 실행될 Exception

> ### JwtAuthenticationToken
- 사용자 인증을 통해 들어온 토큰을 인증할때 사용할 토큰 객체

> ### JwtUserDetails
- 사용자 인증을 통해 토큰에 대한 유저 정보가 담길 객체

> ### JwtUtils
- 토큰에 대한 전반적인 내용을 담당한다
- [x] 토큰의 생성
- [x] 토큰의 인증
- [x] 토큰안에 들어갈 내용
- [x] 토큰의 생명 주기

> ### SecurityConfig
- [x] 각필터의 실행순서와 cors 권한 허용할 URL의 전반적인 처리를 맡는다
- [x] authenticationManager 가 각 토큰을 어떤 Provider를 통해 검증할 것인지 Bean 등록을 통해 설정해 준다
- [x] 각 필터에 필요한 객체를 Spring Container를 통해 주입될 수 있도록 Bean등록을 해준다

