### PR TITLE
Feat : OW-52 회원 API mock 테스트 및 문서화 코드 작성

### DIFF
--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -8,11 +8,43 @@
 === 회원 프로필 이미지 업로드
 이미지를 s3에 업로드 하고, url을 db에 저장합니다.
 
-=== 회원 비밀번호 변경
+#### Request
+include::{snippets}/user/img/http-request.adoc[]
+include::{snippets}/user/img/request-parts.adoc[]
+
+#### Response
+include::{snippets}/user/img/http-response.adoc[]
+include::{snippets}/user/img/response-fields.adoc[]
+
+=== 회원 정보 변경
 회원 정보를 변경합니다. 현재는 변경 가능한 정보가 이름뿐입니다.
+
+#### Request
+include::{snippets}/user/info/http-request.adoc[]
+include::{snippets}/user/info/request-fields.adoc[]
+
+#### Response
+include::{snippets}/user/info/http-response.adoc[]
+
+=== 회원 비밀번호 변경
+회원 비밀번호를 변경합니다. 새로운 비밀번호와 현재 비밀번호를 받아서
+
+#### Request
+include::{snippets}/user/password/http-request.adoc[]
+include::{snippets}/user/password/request-fields.adoc[]
+
+#### Response
+include::{snippets}/user/password/http-response.adoc[]
 
 === 회원 탈퇴
 회원 정보를 변경합니다. 현재는 변경 가능한 정보가 이름뿐입니다.
+
+#### Request
+include::{snippets}/user/deactivate/http-request.adoc[]
+
+#### Response
+include::{snippets}/user/deactivate/http-response.adoc[]
+
 
 == 컨테이너 API
 
@@ -22,10 +54,11 @@ api1
 === API2
 api2
 
+
 == 컨테이너 생성 API
-:toc:
 
 === API1
 api1
 
-=== AP
+=== API2
+api2

--- a/back/src/main/java/com/ogjg/back/user/dto/request/InfoUpdateRequest.java
+++ b/back/src/main/java/com/ogjg/back/user/dto/request/InfoUpdateRequest.java
@@ -10,4 +10,9 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class InfoUpdateRequest {
     String name;
+
+    @Builder
+    public InfoUpdateRequest(String name) {
+        this.name = name;
+    }
 }

--- a/back/src/main/java/com/ogjg/back/user/dto/request/PasswordUpdateRequest.java
+++ b/back/src/main/java/com/ogjg/back/user/dto/request/PasswordUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.ogjg.back.user.dto.request;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,4 +10,9 @@ import static lombok.AccessLevel.PROTECTED;
 @NoArgsConstructor(access = PROTECTED)
 public class PasswordUpdateRequest {
     String password;
+
+    @Builder
+    public PasswordUpdateRequest(String password) {
+        this.password = password;
+    }
 }

--- a/back/src/test/java/com/ogjg/back/BackApplicationTests.java
+++ b/back/src/test/java/com/ogjg/back/BackApplicationTests.java
@@ -9,5 +9,4 @@ class BackApplicationTests {
     @Test
     void contextLoads() {
     }
-
 }

--- a/back/src/test/java/com/ogjg/back/user/common/ControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/user/common/ControllerTest.java
@@ -1,0 +1,45 @@
+package com.ogjg.back.user.common;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ogjg.back.user.controller.UserController;
+import com.ogjg.back.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+
+@AutoConfigureRestDocs
+@WebMvcTest({
+        UserController.class
+})
+public class ControllerTest {
+
+    @RegisterExtension
+    final RestDocumentationExtension restDocumentation = new RestDocumentationExtension();
+
+    // providing an output directory when creating it
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext, RestDocumentationContextProvider restDocumentation) throws Exception {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation))
+                .build();
+    }
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @MockBean
+    protected UserService userService;
+}

--- a/back/src/test/java/com/ogjg/back/user/controller/UserControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/user/controller/UserControllerTest.java
@@ -1,0 +1,164 @@
+package com.ogjg.back.user.controller;
+
+import com.ogjg.back.user.common.ControllerTest;
+import com.ogjg.back.user.domain.User;
+import com.ogjg.back.user.domain.UserStatus;
+import com.ogjg.back.user.dto.request.InfoUpdateRequest;
+import com.ogjg.back.user.dto.request.PasswordUpdateRequest;
+import com.ogjg.back.user.dto.response.ImgUpdateResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class UserControllerTest extends ControllerTest {
+    private User user;
+
+    @BeforeEach
+    public void setUp() {
+        user = User.builder()
+                .email("ogjg1234@naver.com")
+                .password("1q2w3e4r!")
+                .name("이회장")
+                .userImg("temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/ogjg5678@naver.com/{fileName}")
+                .userStatus(UserStatus.ACTIVE)
+                .build();
+    }
+
+
+    @DisplayName("프로필 사진 업로드(변경 시 덮어씀)")
+    @Test
+    public void updateImg() throws Exception {
+        //given
+        String loginEmail = "ogjg1234@naver.com";
+        String url = "temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/" + loginEmail + "/{fileName}";
+
+        ImgUpdateResponse response = ImgUpdateResponse.builder()
+                .url(url)
+                .build();
+
+        given(userService.updateImg(any(MultipartFile.class), eq(loginEmail)))
+                .willReturn(response);
+
+        MockMultipartFile mockFile = new MockMultipartFile("img", "filename.jpg", "image/jpeg", "image content".getBytes());
+
+        //when
+        ResultActions result = this.mockMvc.perform(
+                multipart("/api/users/img")
+                        .file(mockFile)
+                        .with(request -> {
+                            request.setMethod("PATCH");
+                            return request;
+                        })
+        );
+
+        //then
+        result.andDo(document("user/img",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestParts(
+                        partWithName("img").description("업로드할 이미지 데이터")
+                ),
+                responseFields(
+                        fieldWithPath("status.code").description("응답 코드"),
+                        fieldWithPath("status.message").description("응답 메시지"),
+                        fieldWithPath("data.url").description("업로드된 이미지의 url 주소")
+                )
+        )).andExpect(status().isOk());
+    }
+
+
+    @DisplayName("회원 정보 변경")
+    @Test
+    public void updateInfo() throws Exception {
+        //given
+        String loginEmail = "ogjg1234@naver.com";
+        String newName = "이동진";
+
+        InfoUpdateRequest request = InfoUpdateRequest.builder()
+                .name(newName)
+                .build();
+
+        //when
+        doNothing().when(userService).updateInfo(any(InfoUpdateRequest.class), eq(loginEmail));
+
+        //then
+        ResultActions result = this.mockMvc.perform(
+                patch("/api/users/info")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        result.andDo(document("user/info",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                        fieldWithPath("name").description("변경할 새 이름")
+                )
+         )).andExpect(status().isOk());
+     }
+
+    @DisplayName("회원 비밀번호 변경")
+    @Test
+    public void updatePassword() throws Exception {
+        //given
+        String loginEmail = "ogjg1234@naver.com";
+        String newPassword = "1q2w3e4r!@#";
+
+        PasswordUpdateRequest request = PasswordUpdateRequest.builder()
+                .password(newPassword)
+                .build();
+
+        //when
+        doNothing().when(userService).updatePassword(any(PasswordUpdateRequest.class), eq(loginEmail));
+
+        //then
+        ResultActions result = this.mockMvc.perform(
+                patch("/api/users/password")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        result.andDo(document("user/password",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                        fieldWithPath("password").description("변경할 새 이름")
+                )
+        )).andExpect(status().isOk());
+    }
+
+    @DisplayName("회원 탈퇴")
+    @Test
+    public void deactivate() throws Exception {
+        //given
+        String loginEmail = "ogjg1234@naver.com";
+
+        //when
+        doNothing().when(userService).deactivate(eq(loginEmail));
+
+        //then
+        ResultActions result = this.mockMvc.perform(
+                patch("/api/users/deactivate")
+        );
+
+        result.andDo(document("user/deactivate",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint())
+        )).andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
- [x] 공통 로직 처리를 위한 ControllerTest 작성
- @WebMvcTest에 사용할 모든 Service 클래스를 넣어주고, @MockBean을 주입해서 공통로직을 처리하도록 구현
- 현재 Service 객체가 UserService 뿐이어서 하나만 주입되어 있습니다.
- ❗️Controller mock 테스트를 추가할때 ControllerTest에 Service를 추가해주시고, 상속해서 사용해주세요!
- [x] 회원 API mock 테스트 작성
- [x] 노션에 [rest-docs 사용 방법](https://www.notion.so/Spring-Rest-docs-e434df99cf8246c4866364e4c416fd2e?pvs=4) 작성
- [x] 노션에 [rest-docs 보는 방법](https://www.notion.so/API-Spring-REST-Docs-fe69fb8a758d4ad8b8df05a66fb6d0b8?pvs=4) 작성