### PR TITLE
Docs : OW-55 커스텀 스니펫 추가 및 index.adoc 정리

### DIFF
--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -8,41 +8,32 @@
 === 회원 프로필 이미지 업로드
 이미지를 s3에 업로드 하고, url을 db에 저장합니다.
 
-#### Request
 include::{snippets}/user/img/http-request.adoc[]
 include::{snippets}/user/img/request-parts.adoc[]
 
-#### Response
 include::{snippets}/user/img/http-response.adoc[]
 include::{snippets}/user/img/response-fields.adoc[]
 
 === 회원 정보 변경
 회원 정보를 변경합니다. 현재는 변경 가능한 정보가 이름뿐입니다.
 
-#### Request
 include::{snippets}/user/info/http-request.adoc[]
 include::{snippets}/user/info/request-fields.adoc[]
 
-#### Response
 include::{snippets}/user/info/http-response.adoc[]
 
 === 회원 비밀번호 변경
-회원 비밀번호를 변경합니다. 새로운 비밀번호와 현재 비밀번호를 받아서
+회원 비밀번호를 변경합니다.
 
-#### Request
 include::{snippets}/user/password/http-request.adoc[]
 include::{snippets}/user/password/request-fields.adoc[]
 
-#### Response
 include::{snippets}/user/password/http-response.adoc[]
 
 === 회원 탈퇴
-회원 정보를 변경합니다. 현재는 변경 가능한 정보가 이름뿐입니다.
+회원 정보를 변경합니다. 현재는 변경 가능한 정보가 이름 뿐입니다.
 
-#### Request
 include::{snippets}/user/deactivate/http-request.adoc[]
-
-#### Response
 include::{snippets}/user/deactivate/http-response.adoc[]
 
 

--- a/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/http-request.snippet
+++ b/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/http-request.snippet
@@ -1,0 +1,10 @@
+#### Request
+
+[source,http,options="nowrap"]
+----
+{{method}} {{path}} HTTP/1.1
+{{#headers}}
+{{name}}: {{value}}
+{{/headers}}
+{{requestBody}}
+----

--- a/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/http-response.snippet
+++ b/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/http-response.snippet
@@ -1,0 +1,10 @@
+#### Response
+
+[source,http,options="nowrap"]
+----
+HTTP/1.1 {{statusCode}} {{statusReason}}
+{{#headers}}
+{{name}}: {{value}}
+{{/headers}}
+{{responseBody}}
+----

--- a/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
+++ b/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/path-parameters.snippet
@@ -1,0 +1,12 @@
+PathVariables
+
+|===
+|파라미터(경로)|필수값|설명
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+|===

--- a/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/query-parameters.snippet
+++ b/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/query-parameters.snippet
@@ -1,0 +1,12 @@
+QueryParameters
+
+|===
+|파라미터|필수값|설명
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/parameters}}
+|===

--- a/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
+++ b/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-fields.snippet
@@ -1,0 +1,14 @@
+RequestFields
+
+|===
+|필드명|타입|필수값|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===

--- a/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parts.snippet
+++ b/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/request-parts.snippet
@@ -1,0 +1,12 @@
+RequestParts
+
+|===
+|파트|설명
+
+{{#requestParts}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/requestParts}}
+|===

--- a/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
+++ b/back/src/test/resources/org/springframework/restdocs/templates/asciidoctor/response-fields.snippet
@@ -1,0 +1,14 @@
+ResponseFields
+
+|===
+|필드명|타입|필수값|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===


### PR DESCRIPTION
- [x] 커스텀 스니펫을 추가해서 각 스니펫에 섹션 혹은 스니펫 이름이 붙도록 구현
- [x] 커스텀한 내용 반영해서 index.adoc 정리
###
- 아래 두 스니펫을 가장 먼저 오게 문서를 작성하도록 했습니다.
  - http-request.adoc 스니펫에 시작점에 `#### Request` 라고 제목이 붙도록 했고,
  - http-response.adoc 스니펫에 시작점에 `#### Response` 라고 제목이 붙도록 했습니다.
- 나머지 커스텀한 스니펫들에는 시작점에 기본 글자로 간단한 이름만 붙도록 했습니다.
- 현재 지금 push한 커밋의 index.html을 예시로 문서를 작성하는 방식을으로 진행하려고 합니다.

### 문서화 결과 예시
<img width="450" alt="image" src="https://github.com/Goorm-OGJG/Web-IDE/assets/92416661/498da5e8-a696-42c3-9abc-e3fde6a16ef2">



일차적인 문서화는 로직은 이걸로 끝난 것 같습니다. 앞으로 사용하면서 개선점을 많이 말씀해주시면 좋겠습니다!