### PR TITLE
Feat : OW-38 컨테이너 생성 페이지 API 임시 구현

### DIFF
--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -48,8 +48,14 @@ api2
 
 == 컨테이너 생성 API
 
-=== API1
-api1
+=== 컨테이너 생성
+include::{snippets}/container/create/http-request.adoc[]
+include::{snippets}/container/create/request-fields.adoc[]
 
-=== API2
-api2
+include::{snippets}/container/create/http-response.adoc[]
+
+=== 컨테이너 이름 중복체크
+include::{snippets}/container/check/http-request.adoc[]
+include::{snippets}/container/check/query-parameters.adoc[]
+
+include::{snippets}/container/check/http-response.adoc[]

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -11,7 +11,9 @@ public enum ErrorCode {
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "404", "회원를 찾을 수 없습니다"),
     INVALID_FORMAT(HttpStatus.BAD_REQUEST, "400", "데이터 검증 실패"),
     AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "인증에 실패 했습니다"),
-    EMAIL_AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "이메일 인증에 실패 했습니다");
+    EMAIL_AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "이메일 인증에 실패 했습니다"),
+
+    DUPLICATED_CONTAINER_NAME(HttpStatus.BAD_REQUEST , "400", "이미 존재하는 컨테이너 이름입니다");
 
     @JsonIgnore
     private final HttpStatus statusCode;

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -12,7 +12,6 @@ public enum ErrorCode {
     INVALID_FORMAT(HttpStatus.BAD_REQUEST, "400", "데이터 검증 실패"),
     AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "인증에 실패 했습니다"),
     EMAIL_AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "이메일 인증에 실패 했습니다"),
-
     DUPLICATED_CONTAINER_NAME(HttpStatus.BAD_REQUEST , "400", "이미 존재하는 컨테이너 이름입니다");
 
     @JsonIgnore

--- a/back/src/main/java/com/ogjg/back/container/controller/ContainerController.java
+++ b/back/src/main/java/com/ogjg/back/container/controller/ContainerController.java
@@ -1,0 +1,43 @@
+package com.ogjg.back.container.controller;
+
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.response.ApiResponse;
+import com.ogjg.back.container.dto.request.ContainerCreateRequest;
+import com.ogjg.back.container.dto.response.ContainerNameCheckResponse;
+import com.ogjg.back.container.service.ContainerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/containers")
+@RequiredArgsConstructor
+public class ContainerController {
+
+    private final ContainerService containerService;
+
+    /**
+     * 컨테이너 생성
+     */
+    @PostMapping("")
+    public ApiResponse<Void> create(@RequestBody ContainerCreateRequest request) {
+        String loginEmail = "ogjg1234@naver.com";
+
+        containerService.createContainer(loginEmail, request);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
+    /**
+     * 컨테이너 이름 중복체크
+     */
+    @GetMapping("/check")
+    public ApiResponse<ContainerNameCheckResponse> checkDuplication(
+            @RequestParam("name") String containerName
+    ) {
+        String loginEmail = "ogjg1234@naver.com";
+
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS,
+                containerService.checkDuplication(containerName, loginEmail)
+        );
+    }
+}

--- a/back/src/main/java/com/ogjg/back/container/domain/Container.java
+++ b/back/src/main/java/com/ogjg/back/container/domain/Container.java
@@ -2,6 +2,7 @@ package com.ogjg.back.container.domain;
 
 import com.ogjg.back.user.domain.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -44,4 +45,19 @@ public class Container {
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
+
+    @Builder
+    public Container(Long containerId, User user, String name, String description, String language, String containerUrl, Boolean isPrivate, Long availableStorage, Boolean isPinned, LocalDateTime modifiedAt, LocalDateTime createdAt) {
+        this.containerId = containerId;
+        this.user = user;
+        this.name = name;
+        this.description = description;
+        this.language = language;
+        this.containerUrl = containerUrl;
+        this.isPrivate = isPrivate;
+        this.availableStorage = availableStorage;
+        this.isPinned = isPinned;
+        this.modifiedAt = modifiedAt;
+        this.createdAt = createdAt;
+    }
 }

--- a/back/src/main/java/com/ogjg/back/container/dto/request/ContainerCreateRequest.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/request/ContainerCreateRequest.java
@@ -1,0 +1,44 @@
+package com.ogjg.back.container.dto.request;
+
+import com.ogjg.back.container.domain.Container;
+import com.ogjg.back.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ContainerCreateRequest {
+    private String name;
+    private String description;
+    private boolean isPrivate;
+    private String language;
+
+    @Builder
+    public ContainerCreateRequest(String name, String description, boolean isPrivate, String language) {
+        this.name = name;
+        this.description = description;
+        this.isPrivate = isPrivate;
+        this.language = language;
+    }
+
+    // todo : 임시 url 제거
+    public Container toContainer(User user) {
+        return Container.builder()
+                .user(user)
+                .name(name)
+                .description(description)
+                .language(language)
+                .containerUrl("aws temp url.com")
+                .isPrivate(isPrivate)
+                .availableStorage(10L)
+                .isPinned(false)
+                .modifiedAt(LocalDateTime.now())
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainerNameCheckResponse.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainerNameCheckResponse.java
@@ -1,0 +1,24 @@
+package com.ogjg.back.container.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ContainerNameCheckResponse {
+    boolean isDuplicated;
+
+    @Builder
+    public ContainerNameCheckResponse(boolean isDuplicated) {
+        this.isDuplicated = isDuplicated;
+    }
+
+    public static ContainerNameCheckResponse of(boolean isDuplicated) {
+        return ContainerNameCheckResponse.builder()
+                .isDuplicated(isDuplicated)
+                .build();
+    }
+}

--- a/back/src/main/java/com/ogjg/back/container/exception/DuplicatedContainerName.java
+++ b/back/src/main/java/com/ogjg/back/container/exception/DuplicatedContainerName.java
@@ -1,0 +1,19 @@
+package com.ogjg.back.container.exception;
+
+import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorData;
+
+public class DuplicatedContainerName extends CustomException {
+    public DuplicatedContainerName() {
+        super(ErrorCode.DUPLICATED_CONTAINER_NAME);
+    }
+
+    public DuplicatedContainerName(String message) {
+        super(ErrorCode.DUPLICATED_CONTAINER_NAME, message);
+    }
+
+    public DuplicatedContainerName(ErrorData errorData) {
+        super(ErrorCode.DUPLICATED_CONTAINER_NAME, errorData);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/container/repository/ContainerRepository.java
+++ b/back/src/main/java/com/ogjg/back/container/repository/ContainerRepository.java
@@ -1,0 +1,22 @@
+package com.ogjg.back.container.repository;
+
+import com.ogjg.back.container.domain.Container;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ContainerRepository extends JpaRepository<Container, Long> {
+
+    @Query("""
+        select c from Container c 
+            join c.user u
+            where c.name =:containerName 
+            and c.user.email =:email
+    """)
+    Optional<Container> findByNameAndEmail(
+            @Param("containerName") String containerName,
+            @Param("email")String email
+    );
+}

--- a/back/src/main/java/com/ogjg/back/container/service/ContainerService.java
+++ b/back/src/main/java/com/ogjg/back/container/service/ContainerService.java
@@ -43,7 +43,7 @@ public class ContainerService {
         );
     }
 
-    private boolean isDuplicated(String containerName, String loginEmail) {
+    protected boolean isDuplicated(String containerName, String loginEmail) {
        return containerRepository.findByNameAndEmail(containerName, loginEmail)
                 .isPresent();
     }

--- a/back/src/main/java/com/ogjg/back/container/service/ContainerService.java
+++ b/back/src/main/java/com/ogjg/back/container/service/ContainerService.java
@@ -1,0 +1,50 @@
+package com.ogjg.back.container.service;
+
+import com.ogjg.back.container.domain.Container;
+import com.ogjg.back.container.dto.request.ContainerCreateRequest;
+import com.ogjg.back.container.dto.response.ContainerNameCheckResponse;
+import com.ogjg.back.container.exception.DuplicatedContainerName;
+import com.ogjg.back.container.repository.ContainerRepository;
+import com.ogjg.back.user.domain.User;
+import com.ogjg.back.user.exception.NotFoundUser;
+import com.ogjg.back.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ContainerService {
+
+    private final ContainerRepository containerRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createContainer(String loginEmail, ContainerCreateRequest request) {
+        User user = userRepository.findByEmail(loginEmail)
+                .orElseThrow(() -> new NotFoundUser());
+
+        if (isDuplicated(request.getName(), loginEmail)) {
+            throw new DuplicatedContainerName();
+        }
+
+        Container container = request.toContainer(user);
+
+        // todo: s3에 컨테이너 생성
+        // todo: 필요하다면 디렉토리 구조 db에 반영
+
+        containerRepository.save(container);
+    }
+
+    @Transactional(readOnly = true)
+    public ContainerNameCheckResponse checkDuplication(String containerName, String loginEmail) {
+        return ContainerNameCheckResponse.of(
+                isDuplicated(containerName, loginEmail)
+        );
+    }
+
+    private boolean isDuplicated(String containerName, String loginEmail) {
+       return containerRepository.findByNameAndEmail(containerName, loginEmail)
+                .isPresent();
+    }
+}

--- a/back/src/main/java/com/ogjg/back/user/controller/UserController.java
+++ b/back/src/main/java/com/ogjg/back/user/controller/UserController.java
@@ -22,7 +22,7 @@ import java.util.Map;
 @Slf4j
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("api/users")
+@RequestMapping("/api/users")
 public class UserController {
 
     private final EmailAuthService emailAuthService;

--- a/back/src/main/java/com/ogjg/back/user/domain/User.java
+++ b/back/src/main/java/com/ogjg/back/user/domain/User.java
@@ -45,6 +45,12 @@ public class User {
         this.emailAuth = emailAuth;
     }
 
+    public static User reference(String loginEmail) {
+        return User.builder()
+                .email(loginEmail)
+                .build();
+    }
+
     public User updateImg(String aws_url) {
         this.userImg = aws_url;
         return this;

--- a/back/src/test/java/com/ogjg/back/common/ControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/common/ControllerTest.java
@@ -1,7 +1,10 @@
-package com.ogjg.back.user.common;
+package com.ogjg.back.common;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ogjg.back.container.controller.ContainerController;
+import com.ogjg.back.container.service.ContainerService;
 import com.ogjg.back.user.controller.UserController;
+import com.ogjg.back.user.service.EmailAuthService;
 import com.ogjg.back.user.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -19,7 +22,8 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 
 @AutoConfigureRestDocs
 @WebMvcTest({
-        UserController.class
+        UserController.class,
+        ContainerController.class
 })
 public class ControllerTest {
 
@@ -42,4 +46,10 @@ public class ControllerTest {
 
     @MockBean
     protected UserService userService;
+
+    @MockBean
+    protected ContainerService containerService;
+
+    @MockBean
+    protected EmailAuthService emailAuthService;
 }

--- a/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
@@ -1,0 +1,91 @@
+package com.ogjg.back.container.controller;
+
+import com.ogjg.back.common.ControllerTest;
+import com.ogjg.back.container.dto.request.ContainerCreateRequest;
+import com.ogjg.back.container.dto.response.ContainerNameCheckResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ContainerControllerTest extends ControllerTest {
+
+    @DisplayName("컨테이너 생성")
+    @Test
+    public void create() throws Exception {
+        //given
+        ContainerCreateRequest request = ContainerCreateRequest.builder()
+                .name("이회장")
+                .description("자바 연습 할거야")
+                .isPrivate(false)
+                .language("Java")
+                .build();
+
+        doNothing()
+                .when(containerService)
+                .createContainer(any(String.class), eq(request));
+
+        // when
+        ResultActions result = this.mockMvc.perform(
+                post("/api/containers")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andDo(document("container/create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                        fieldWithPath("name").description("컨테이너 이름"),
+                        fieldWithPath("description").description("컨테이너 설명").optional(),
+                        fieldWithPath("private").description("비공개 여부"),
+                        fieldWithPath("language").description("프로그래밍 언어")
+                )
+        )).andExpect(status().isOk());
+     }
+
+    @DisplayName("컨테이너 이름 중복 체크")
+    @Test
+    public void checkDuplication() throws Exception {
+        //given
+        ContainerNameCheckResponse response = ContainerNameCheckResponse.builder()
+                .isDuplicated(true)
+                .build();
+
+        given(containerService.checkDuplication(any(String.class), any(String.class)))
+                .willReturn(response);
+
+        // when
+        ResultActions result = this.mockMvc.perform(
+                get("/api/containers/check")
+                        .param("name", "컨테이너 1")
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andDo(document("container/check",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                queryParameters(
+                        parameterWithName("name").description("이름")
+                ),
+                responseFields(
+                        fieldWithPath("status.code").description("응답 코드"),
+                        fieldWithPath("status.message").description("응답 메시지"),
+                        fieldWithPath("data.duplicated").description("중복 여부")
+                )
+        )).andExpect(status().isOk());
+    }
+}

--- a/back/src/test/java/com/ogjg/back/container/service/ContainerServiceTest.java
+++ b/back/src/test/java/com/ogjg/back/container/service/ContainerServiceTest.java
@@ -1,0 +1,133 @@
+package com.ogjg.back.container.service;
+
+import com.ogjg.back.container.domain.Container;
+import com.ogjg.back.container.dto.request.ContainerCreateRequest;
+import com.ogjg.back.container.dto.response.ContainerNameCheckResponse;
+import com.ogjg.back.container.repository.ContainerRepository;
+import com.ogjg.back.user.domain.User;
+import com.ogjg.back.user.domain.UserStatus;
+import com.ogjg.back.user.exception.NotFoundUser;
+import com.ogjg.back.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ContainerServiceTest {
+
+    @InjectMocks
+    private ContainerService containerService;
+
+    @Mock
+    private ContainerRepository containerRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    public void setUser() {
+        user = User.builder()
+                .email("ogjg1234@naver.com")
+                .password("1q2w3e4r!")
+                .name("김회원")
+                .userImg("temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/ogjg1234@naver.com/{fileName}")
+                .userStatus(UserStatus.ACTIVE)
+                .build();
+    }
+
+    @DisplayName("컨테이너 생성 - 유효한 요청이면 컨테이너 생성")
+    @Test
+    public void createContainer() {
+        // given
+        String loginEmail = "ogjg1234@naver.com";
+        ContainerCreateRequest request = ContainerCreateRequest.builder()
+                .name("컨테이너1")
+                .description("자바 연습")
+                .isPrivate(false)
+                .language("Java")
+                .build();
+
+        given(userRepository.findByEmail(loginEmail))
+                .willReturn(Optional.of(user));
+
+        // when
+        containerService.createContainer(loginEmail, request);
+
+        // then
+        then(containerRepository).should().save(any(Container.class));
+    }
+
+    @DisplayName("컨테이너 생성 - 유저가 존재하지 않는 경우")
+    @Test
+    public void createContainer_userNotFound() {
+        // given
+        String loginEmail = "nonexistent@naver.com";
+        ContainerCreateRequest request = ContainerCreateRequest.builder()
+                .name("컨테이너1")
+                .description("자바 연습")
+                .isPrivate(false)
+                .language("Java")
+                .build();
+
+        given(userRepository.findByEmail(loginEmail))
+                .willReturn(Optional.empty());
+
+        // when, then
+        assertThatThrownBy(() -> containerService.createContainer(loginEmail, request))
+                .isInstanceOf(NotFoundUser.class);
+    }
+
+    @DisplayName("컨테이너 이름 중복 체크 - 이름이 존재한다면 true를 반환")
+    @Test
+    public void checkDuplication_true() {
+        // given
+        String containerName = "컨테이너1";
+        String loginEmail = "ogjg1234@naver.com";
+
+        Container container = Container.builder()
+                .build();
+
+        given(containerRepository.findByNameAndEmail(eq(containerName), eq(loginEmail)))
+                .willReturn(Optional.of(container));
+
+        // when
+        ContainerNameCheckResponse response = containerService.checkDuplication(containerName, loginEmail);
+
+        // then
+        assertThat(response.isDuplicated()).isTrue();
+    }
+
+
+    @DisplayName("컨테이너 이름 중복 체크 - 이름이 존재하지 않는다면 false를 반환")
+    @Test
+    public void checkDuplication_false() {
+        // given
+        String containerName = "컨테이너1";
+        String loginEmail = "ogjg1234@naver.com";
+
+        Container container = Container.builder()
+                .build();
+
+        given(containerRepository.findByNameAndEmail(eq(containerName), eq(loginEmail)))
+                .willReturn(Optional.empty());
+
+        // when
+        ContainerNameCheckResponse response = containerService.checkDuplication(containerName, loginEmail);
+
+        // then
+        assertThat(response.isDuplicated()).isFalse();
+    }
+}
+

--- a/back/src/test/java/com/ogjg/back/container/service/ContainerServiceTest.java
+++ b/back/src/test/java/com/ogjg/back/container/service/ContainerServiceTest.java
@@ -3,6 +3,7 @@ package com.ogjg.back.container.service;
 import com.ogjg.back.container.domain.Container;
 import com.ogjg.back.container.dto.request.ContainerCreateRequest;
 import com.ogjg.back.container.dto.response.ContainerNameCheckResponse;
+import com.ogjg.back.container.exception.DuplicatedContainerName;
 import com.ogjg.back.container.repository.ContainerRepository;
 import com.ogjg.back.user.domain.User;
 import com.ogjg.back.user.domain.UserStatus;
@@ -47,7 +48,7 @@ public class ContainerServiceTest {
                 .build();
     }
 
-    @DisplayName("컨테이너 생성 - 유효한 요청이면 컨테이너 생성")
+    @DisplayName("컨테이너 생성 - 유저가 존재하고, 중복되는 컨테이너 이름이 없다면 컨테이너 생성")
     @Test
     public void createContainer() {
         // given
@@ -62,6 +63,9 @@ public class ContainerServiceTest {
         given(userRepository.findByEmail(loginEmail))
                 .willReturn(Optional.of(user));
 
+        given(containerRepository.findByNameAndEmail(request.getName(), loginEmail))
+                .willReturn(Optional.empty());
+
         // when
         containerService.createContainer(loginEmail, request);
 
@@ -69,7 +73,7 @@ public class ContainerServiceTest {
         then(containerRepository).should().save(any(Container.class));
     }
 
-    @DisplayName("컨테이너 생성 - 유저가 존재하지 않는 경우")
+    @DisplayName("컨테이너 생성 예외 - 유저가 존재하지 않는 경우")
     @Test
     public void createContainer_userNotFound() {
         // given
@@ -87,6 +91,33 @@ public class ContainerServiceTest {
         // when, then
         assertThatThrownBy(() -> containerService.createContainer(loginEmail, request))
                 .isInstanceOf(NotFoundUser.class);
+    }
+
+    @DisplayName("컨테이너 생성 예외 - 유저가 존재하지만, 컨테이너 이름이 중복되는 경우")
+    @Test
+    public void createContainer_duplicated_container_name() {
+        // given
+        String loginEmail = "ogjg1234@naver.com";
+        ContainerCreateRequest request = ContainerCreateRequest.builder()
+                .name("컨테이너1")
+                .description("자바 연습")
+                .isPrivate(false)
+                .language("Java")
+                .build();
+
+        Container existContainer = Container.builder()
+                .name("컨테이너1")
+                .build();
+
+        given(userRepository.findByEmail(loginEmail))
+                .willReturn(Optional.of(user));
+
+        given(containerRepository.findByNameAndEmail(request.getName(), loginEmail))
+                .willReturn(Optional.of(existContainer));
+
+        // when, then
+        assertThatThrownBy(() -> containerService.createContainer(loginEmail, request))
+                .isInstanceOf(DuplicatedContainerName.class);
     }
 
     @DisplayName("컨테이너 이름 중복 체크 - 이름이 존재한다면 true를 반환")

--- a/back/src/test/java/com/ogjg/back/user/controller/UserControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/user/controller/UserControllerTest.java
@@ -1,12 +1,9 @@
 package com.ogjg.back.user.controller;
 
-import com.ogjg.back.user.common.ControllerTest;
-import com.ogjg.back.user.domain.User;
-import com.ogjg.back.user.domain.UserStatus;
+import com.ogjg.back.common.ControllerTest;
 import com.ogjg.back.user.dto.request.InfoUpdateRequest;
 import com.ogjg.back.user.dto.request.PasswordUpdateRequest;
 import com.ogjg.back.user.dto.response.ImgUpdateResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -25,19 +22,6 @@ import static org.springframework.restdocs.request.RequestDocumentation.requestP
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class UserControllerTest extends ControllerTest {
-    private User user;
-
-    @BeforeEach
-    public void setUp() {
-        user = User.builder()
-                .email("ogjg1234@naver.com")
-                .password("1q2w3e4r!")
-                .name("이회장")
-                .userImg("temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/ogjg5678@naver.com/{fileName}")
-                .userStatus(UserStatus.ACTIVE)
-                .build();
-    }
-
 
     @DisplayName("프로필 사진 업로드(변경 시 덮어씀)")
     @Test
@@ -92,16 +76,16 @@ public class UserControllerTest extends ControllerTest {
                 .name(newName)
                 .build();
 
-        //when
         doNothing().when(userService).updateInfo(any(InfoUpdateRequest.class), eq(loginEmail));
 
-        //then
+        //when
         ResultActions result = this.mockMvc.perform(
                 patch("/api/users/info")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
         );
 
+        //then
         result.andDo(document("user/info",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
@@ -122,10 +106,9 @@ public class UserControllerTest extends ControllerTest {
                 .password(newPassword)
                 .build();
 
-        //when
         doNothing().when(userService).updatePassword(any(PasswordUpdateRequest.class), eq(loginEmail));
 
-        //then
+        //when
         ResultActions result = this.mockMvc.perform(
                 patch("/api/users/password")
                         .content(objectMapper.writeValueAsString(request))
@@ -133,6 +116,7 @@ public class UserControllerTest extends ControllerTest {
                         .accept(MediaType.APPLICATION_JSON)
         );
 
+        //then
         result.andDo(document("user/password",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
@@ -148,14 +132,14 @@ public class UserControllerTest extends ControllerTest {
         //given
         String loginEmail = "ogjg1234@naver.com";
 
-        //when
         doNothing().when(userService).deactivate(eq(loginEmail));
 
-        //then
+        //when
         ResultActions result = this.mockMvc.perform(
                 patch("/api/users/deactivate")
         );
 
+        //then
         result.andDo(document("user/deactivate",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint())

--- a/back/src/test/java/com/ogjg/back/user/service/EmailAuthServiceTest.java
+++ b/back/src/test/java/com/ogjg/back/user/service/EmailAuthServiceTest.java
@@ -1,6 +1,5 @@
 package com.ogjg.back.user.service;
 
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -12,10 +11,10 @@ class EmailAuthServiceTest {
 
 
 
-    @Test
-    void userExceptionTest(){
-
-    }
+//    @Test
+//    void userExceptionTest(){
+//
+//    }
 
 
 }

--- a/back/src/test/java/com/ogjg/back/user/service/UserServiceIntegrationTest.java
+++ b/back/src/test/java/com/ogjg/back/user/service/UserServiceIntegrationTest.java
@@ -4,7 +4,7 @@ import com.ogjg.back.user.domain.User;
 import com.ogjg.back.user.domain.UserStatus;
 import com.ogjg.back.user.exception.NotFoundUser;
 import com.ogjg.back.user.repository.UserRepository;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,21 +15,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
-public class UserServiceTest {
+public class UserServiceIntegrationTest {
 
-    static User user;
+    private User user;
     @Autowired
-    UserService userService;
+    private UserService userService;
     @Autowired
-    UserRepository userRepository;
+    private UserRepository userRepository;
 
-    @BeforeAll
-    public static void setUp() {
+    @BeforeEach
+    public void setUser() {
         user = User.builder()
                 .email("ogjg1234@naver.com")
                 .password("1q2w3e4r!")
                 .name("김회원")
-                .userImg("temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/" + 1L + "/{fileName}")
+                .userImg("temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/ogjg1234@naver.com/{fileName}")
                 .userStatus(UserStatus.ACTIVE)
                 .build();
     }


### PR DESCRIPTION
### Feat : OW-38 컨테이너 생성 페이지 기능 임시 구현

- [x] 컨테이너 생성 기능 구현
  - s3 로직 제외하고 구현
- [x] 컨테이너 이름 중복체크 기능 구현
- [x]  Controller mapping 경로에 누락된 / 추가
### Test : OW-38 컨테이너 생성 페이지 테스트 작성, User 테스트 관련 정리

- [x] 컨테이너 생성 기능 Controller와 Service 테스트 작성
- [x] 추가된 테스트 내용에 대해 adoc 작성
- [x] User 테스트 given, when, then 위치 수정 및 네이밍 수정
- [x] 누락된 접근제어자 추가
- [x]  ControllerTest에 EmailAuthService MockBean 추가
