### PR TITLE
Feat : OW-61 회원 프로필 이미지를 S3에 업로드하는 로직 추가

### DIFF
--- a/back/build.gradle
+++ b/back/build.gradle
@@ -50,6 +50,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    // aws s3
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.556'
+
     // rest-docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'

--- a/back/build.gradle
+++ b/back/build.gradle
@@ -51,7 +51,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
     // aws s3
-    implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.556'
+    implementation platform('software.amazon.awssdk:bom:2.20.56')
+    implementation 'software.amazon.awssdk:s3'
 
     // rest-docs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -13,7 +13,8 @@ public enum ErrorCode {
     AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "인증에 실패 했습니다"),
     EMAIL_AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "이메일 인증에 실패 했습니다"),
     DUPLICATED_CONTAINER_NAME(HttpStatus.BAD_REQUEST , "400", "이미 존재하는 컨테이너 이름입니다"),
-    INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "400", "현재 비밀번호 불일치");
+    INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "400", "현재 비밀번호 불일치"),
+    S3_FAIL_TO_UPLOAD_IMAGE(HttpStatus.BAD_REQUEST, "400","S3에 프로필 이미지 업로드를 실패했습니다.");
 
     @JsonIgnore
     private final HttpStatus statusCode;

--- a/back/src/main/java/com/ogjg/back/config/S3Config.java
+++ b/back/src/main/java/com/ogjg/back/config/S3Config.java
@@ -1,0 +1,32 @@
+package com.ogjg.back.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/back/src/main/java/com/ogjg/back/config/S3Config.java
+++ b/back/src/main/java/com/ogjg/back/config/S3Config.java
@@ -1,12 +1,13 @@
 package com.ogjg.back.config;
 
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
 
 @Configuration
 public class S3Config {
@@ -21,12 +22,13 @@ public class S3Config {
     private String region;
 
     @Bean
-    public AmazonS3Client amazonS3Client() {
-        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
 
-        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
-                .withCredentials(new AWSStaticCredentialsProvider(credentials))
-                .withRegion(region)
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
                 .build();
     }
 }
+

--- a/back/src/main/java/com/ogjg/back/s3/exception/S3ImageUploadException.java
+++ b/back/src/main/java/com/ogjg/back/s3/exception/S3ImageUploadException.java
@@ -1,0 +1,19 @@
+package com.ogjg.back.s3.exception;
+
+import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorData;
+
+public class S3ImageUploadException extends CustomException {
+    public S3ImageUploadException() {
+        super(ErrorCode.S3_FAIL_TO_UPLOAD_IMAGE);
+    }
+
+    public S3ImageUploadException(String message) {
+        super(ErrorCode.S3_FAIL_TO_UPLOAD_IMAGE, message);
+    }
+
+    public S3ImageUploadException(ErrorData errorData) {
+        super(ErrorCode.S3_FAIL_TO_UPLOAD_IMAGE, errorData);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3Repository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3Repository.java
@@ -1,17 +1,15 @@
 package com.ogjg.back.s3.repository;
 
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.ListObjectsV2Request;
-import com.amazonaws.services.s3.model.ListObjectsV2Result;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
 
-import java.util.Optional;
+import java.util.*;
 
 @Slf4j
 @Repository
@@ -20,38 +18,102 @@ public class S3Repository {
 
     @Value("${cloud.aws.credentials.bucket-name}")
     private String bucketName;
-    private final AmazonS3Client amazonS3Client;
+    private final S3Client s3Client;
 
-    public void deleteObjectsWithPrefix(String prefix) {
-        ListObjectsV2Request request = new ListObjectsV2Request().withBucketName(bucketName).withPrefix(prefix);
-        ListObjectsV2Result result;
-
-        do {
-            result = amazonS3Client.listObjectsV2(request);
-
-            for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
-                amazonS3Client.deleteObject(bucketName, objectSummary.getKey());
-            }
-
-            // 최대 키 개수 단위인 1000개 넘기면 다음 batch로 가야한다.
-            request.setContinuationToken(result.getNextContinuationToken());
-        } while (result.isTruncated()); // 객체가 더 있는지 확인
-    }
-
-    public Optional<String> uploadFile(MultipartFile multipartFile, String filename) {
+    public Optional<String> uploadFile(MultipartFile file, String filename) {
         String accessUrl = null;
         try {
-            ObjectMetadata objectMetadata = new ObjectMetadata();
-            objectMetadata.setContentType(multipartFile.getContentType());
-            objectMetadata.setContentLength(multipartFile.getInputStream().available());
+            Map<String, String> metadata = new HashMap<>();
+            metadata.put("x-amz-meta-myVal", "test");
+            PutObjectRequest putObjRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(filename)
+                    .metadata(metadata)
+                    .build();
 
-            amazonS3Client.putObject(bucketName, filename, multipartFile.getInputStream(), objectMetadata);
+            s3Client.putObject(putObjRequest,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
 
-            accessUrl = amazonS3Client.getUrl(bucketName, filename).toString();
-        } catch(Exception e) {
-            log.info("error message={}",e.getMessage());
+            accessUrl = getUrl(filename);
+            log.info("accessUrl={}",accessUrl);
+
+        } catch (Exception e) {
+            log.error("error message={}",e.getMessage());
         }
 
         return Optional.of(accessUrl);
+    }
+
+    private String getUrl(String fileName) {
+        GetUrlRequest getUrlRequest = GetUrlRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+
+        return s3Client.utilities()
+                .getUrl(getUrlRequest).toString();
+    }
+
+    public void deleteObjectsWithPrefix(String prefix) {
+        try {
+            ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder()
+                    .bucket(bucketName)
+                    .prefix(prefix)
+                    .build();
+
+            s3Client.listObjectsV2(listObjectsV2Request).contents().stream()
+                    .map((content) -> toDeleteObjectRequest(content))
+                    .forEach((request) -> s3Client.deleteObject(request));
+
+        } catch (Exception e) {
+            log.error("error message={}",e.getMessage());
+        }
+    }
+
+    private DeleteObjectRequest toDeleteObjectRequest(S3Object content) {
+        return DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(content.key())
+                .build();
+    }
+
+    public void deleteBatchWithPrefix(String prefix) {
+        try {
+            ListObjectsRequest listObjectsRequest = ListObjectsRequest.builder()
+                    .bucket(bucketName)
+                    .prefix(prefix)
+                    .build();
+
+            ListObjectsResponse listObjectsResponse;
+            do {
+                listObjectsResponse = s3Client.listObjects(listObjectsRequest);
+                List<S3Object> s3Objects = listObjectsResponse.contents();
+
+                List<ObjectIdentifier> toDelete = new ArrayList<>();
+                for (S3Object s3Object : s3Objects) {
+                    ObjectIdentifier objIdentifier = ObjectIdentifier.builder().key(s3Object.key()).build();
+                    toDelete.add(objIdentifier);
+                }
+
+                if (!toDelete.isEmpty()) {
+                    DeleteObjectsRequest deleteObjectsRequest = DeleteObjectsRequest.builder()
+                            .bucket(bucketName)
+                            .delete(Delete.builder().objects(toDelete).build())
+                            .build();
+
+                    s3Client.deleteObjects(deleteObjectsRequest);
+                }
+
+                listObjectsRequest = ListObjectsRequest.builder()
+                        .bucket(bucketName)
+                        .prefix(prefix)
+                        .marker(listObjectsResponse.nextMarker())
+                        .build();
+
+            } while (listObjectsResponse.isTruncated());
+
+        } catch (Exception e) {
+            log.error("error message={}",e.getMessage());
+        }
     }
 }

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3Repository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3Repository.java
@@ -38,16 +38,16 @@ public class S3Repository {
         } while (result.isTruncated()); // 객체가 더 있는지 확인
     }
 
-    public Optional<String> uploadFile(MultipartFile multipartFile, String fileName) {
+    public Optional<String> uploadFile(MultipartFile multipartFile, String filename) {
         String accessUrl = null;
         try {
             ObjectMetadata objectMetadata = new ObjectMetadata();
             objectMetadata.setContentType(multipartFile.getContentType());
             objectMetadata.setContentLength(multipartFile.getInputStream().available());
 
-            amazonS3Client.putObject(bucketName, fileName, multipartFile.getInputStream(), objectMetadata);
+            amazonS3Client.putObject(bucketName, filename, multipartFile.getInputStream(), objectMetadata);
 
-            accessUrl = amazonS3Client.getUrl(bucketName, fileName).toString();
+            accessUrl = amazonS3Client.getUrl(bucketName, filename).toString();
         } catch(Exception e) {
             log.info("error message={}",e.getMessage());
         }

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3Repository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3Repository.java
@@ -1,0 +1,57 @@
+package com.ogjg.back.s3.repository;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class S3Repository {
+
+    @Value("${cloud.aws.credentials.bucket-name}")
+    private String bucketName;
+    private final AmazonS3Client amazonS3Client;
+
+    public void deleteObjectsWithPrefix(String prefix) {
+        ListObjectsV2Request request = new ListObjectsV2Request().withBucketName(bucketName).withPrefix(prefix);
+        ListObjectsV2Result result;
+
+        do {
+            result = amazonS3Client.listObjectsV2(request);
+
+            for (S3ObjectSummary objectSummary : result.getObjectSummaries()) {
+                amazonS3Client.deleteObject(bucketName, objectSummary.getKey());
+            }
+
+            // 최대 키 개수 단위인 1000개 넘기면 다음 batch로 가야한다.
+            request.setContinuationToken(result.getNextContinuationToken());
+        } while (result.isTruncated()); // 객체가 더 있는지 확인
+    }
+
+    public Optional<String> uploadFile(MultipartFile multipartFile, String fileName) {
+        String accessUrl = null;
+        try {
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentType(multipartFile.getContentType());
+            objectMetadata.setContentLength(multipartFile.getInputStream().available());
+
+            amazonS3Client.putObject(bucketName, fileName, multipartFile.getInputStream(), objectMetadata);
+
+            accessUrl = amazonS3Client.getUrl(bucketName, fileName).toString();
+        } catch(Exception e) {
+            log.info("error message={}",e.getMessage());
+        }
+
+        return Optional.of(accessUrl);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/s3/service/S3ProfileImageService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3ProfileImageService.java
@@ -25,11 +25,10 @@ public class S3ProfileImageService {
         String prefix = email + "/image.";
         s3Repository.deleteObjectsWithPrefix(prefix);
 
-        String filename = prefix + extractExtension(originalName);
-        String accessUrl = s3Repository.uploadFile(multipartFile, filename)
-                .orElseThrow(() -> new S3ImageUploadException());
+        String fileName = prefix + extractExtension(originalName);
 
-        return accessUrl;
+        return s3Repository.uploadFile(multipartFile, fileName)
+                .orElseThrow(() -> new S3ImageUploadException());
     }
 
     private String extractExtension(String originName) {

--- a/back/src/main/java/com/ogjg/back/s3/service/S3ProfileImageService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3ProfileImageService.java
@@ -25,8 +25,8 @@ public class S3ProfileImageService {
         String prefix = email + "/image.";
         s3Repository.deleteObjectsWithPrefix(prefix);
 
-        String fileName = prefix + extractExtension(originalName);
-        String accessUrl = s3Repository.uploadFile(multipartFile, fileName)
+        String filename = prefix + extractExtension(originalName);
+        String accessUrl = s3Repository.uploadFile(multipartFile, filename)
                 .orElseThrow(() -> new S3ImageUploadException());
 
         return accessUrl;

--- a/back/src/main/java/com/ogjg/back/s3/service/S3ProfileImageService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3ProfileImageService.java
@@ -1,0 +1,40 @@
+package com.ogjg.back.s3.service;
+
+import com.ogjg.back.s3.exception.S3ImageUploadException;
+import com.ogjg.back.s3.repository.S3Repository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3ProfileImageService {
+    private final S3Repository s3Repository;
+
+    /**
+     * 기존에 존재하는 프로필 이미지를 삭제하고, 새 이미지를 저장한다.
+     */
+    @Transactional
+    public String saveImage(MultipartFile multipartFile, String email) {
+        String originalName = multipartFile.getOriginalFilename();
+
+        // 컨테이너 이름에 . 을 넣을수 없다. image. 을 prefix로 이미지를 지우고 다시 생성한다.
+        String prefix = email + "/image.";
+        s3Repository.deleteObjectsWithPrefix(prefix);
+
+        String fileName = prefix + extractExtension(originalName);
+        String accessUrl = s3Repository.uploadFile(multipartFile, fileName)
+                .orElseThrow(() -> new S3ImageUploadException());
+
+        return accessUrl;
+    }
+
+    private String extractExtension(String originName) {
+        int index = originName.lastIndexOf('.');
+
+        return originName.substring(index + 1); // .제외한 확장자만 추출한다.
+    }
+}

--- a/back/src/main/java/com/ogjg/back/user/controller/UserController.java
+++ b/back/src/main/java/com/ogjg/back/user/controller/UserController.java
@@ -2,10 +2,7 @@ package com.ogjg.back.user.controller;
 
 import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.response.ApiResponse;
-import com.ogjg.back.user.dto.request.EmailAuthRequest;
-import com.ogjg.back.user.dto.request.InfoUpdateRequest;
-import com.ogjg.back.user.dto.request.PasswordUpdateRequest;
-import com.ogjg.back.user.dto.request.UserRequest;
+import com.ogjg.back.user.dto.request.*;
 import com.ogjg.back.user.dto.response.ImgUpdateResponse;
 import com.ogjg.back.user.service.EmailAuthService;
 import com.ogjg.back.user.service.UserService;
@@ -47,13 +44,13 @@ public class UserController {
      */
     @PatchMapping("/img")
     public ApiResponse<ImgUpdateResponse> updateImg(
-            @RequestParam("img") MultipartFile imgFile
+            @RequestParam("img") MultipartFile multipartFile
     ) {
         String loginEmail = "ogjg1234@naver.com";
 
         return new ApiResponse<>(
                 ErrorCode.SUCCESS,
-                userService.updateImg(imgFile, loginEmail)
+                userService.updateImg(multipartFile, loginEmail)
         );
     }
 

--- a/back/src/main/java/com/ogjg/back/user/domain/User.java
+++ b/back/src/main/java/com/ogjg/back/user/domain/User.java
@@ -47,12 +47,6 @@ public class User {
         this.emailAuth = emailAuth;
     }
 
-    public static User reference(String loginEmail) {
-        return User.builder()
-                .email(loginEmail)
-                .build();
-    }
-
     public User updateImg(String aws_url) {
         this.userImg = aws_url;
         return this;

--- a/back/src/main/java/com/ogjg/back/user/service/UserService.java
+++ b/back/src/main/java/com/ogjg/back/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.ogjg.back.user.service;
 
+import com.ogjg.back.s3.service.S3ProfileImageService;
 import com.ogjg.back.user.domain.User;
 import com.ogjg.back.user.dto.request.InfoUpdateRequest;
 import com.ogjg.back.user.dto.request.PasswordUpdateRequest;
@@ -17,16 +18,15 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final S3ProfileImageService s3ProfileImageService;
 
     @Transactional
-    public ImgUpdateResponse updateImg(MultipartFile imgFile, String loginEmail) {
+    public ImgUpdateResponse updateImg(MultipartFile multipartFile, String loginEmail) {
         User findUser = findByEmail(loginEmail);
 
-        // todo : 이미지 데이터 aws 업로드 로직 추가
-        // S3에 파일 데이터 저장 후, 경로 반환
-        String aws_url = "temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/" + findUser.getEmail() + "/{fileName}";
+        String url = s3ProfileImageService.saveImage(multipartFile, loginEmail);
 
-        User user = findUser.updateImg(aws_url);
+        User user = findUser.updateImg(url);
         return ImgUpdateResponse.of(user);
     }
 

--- a/back/src/test/java/com/ogjg/back/common/ControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/common/ControllerTest.java
@@ -3,6 +3,7 @@ package com.ogjg.back.common;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ogjg.back.container.controller.ContainerController;
 import com.ogjg.back.container.service.ContainerService;
+import com.ogjg.back.s3.service.S3ProfileImageService;
 import com.ogjg.back.user.controller.UserController;
 import com.ogjg.back.user.service.EmailAuthService;
 import com.ogjg.back.user.service.UserService;
@@ -52,4 +53,7 @@ public class ControllerTest {
 
     @MockBean
     protected EmailAuthService emailAuthService;
+
+    @MockBean
+    protected S3ProfileImageService s3ProfileImageService;
 }

--- a/back/src/test/java/com/ogjg/back/user/controller/UserControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/user/controller/UserControllerTest.java
@@ -27,8 +27,10 @@ public class UserControllerTest extends ControllerTest {
     @Test
     public void updateImg() throws Exception {
         //given
+        String originFilename = "filename.jpg";
         String loginEmail = "ogjg1234@naver.com";
-        String url = "temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/" + loginEmail + "/{fileName}";
+        String url = "https://{bucket}.{region}.amazonaws.com/"+loginEmail+"/"+originFilename;
+        MockMultipartFile multipartFile = new MockMultipartFile("img", originFilename, "image/jpeg", "image content".getBytes());
 
         ImgUpdateResponse response = ImgUpdateResponse.builder()
                 .url(url)
@@ -37,12 +39,10 @@ public class UserControllerTest extends ControllerTest {
         given(userService.updateImg(any(MultipartFile.class), eq(loginEmail)))
                 .willReturn(response);
 
-        MockMultipartFile mockFile = new MockMultipartFile("img", "filename.jpg", "image/jpeg", "image content".getBytes());
-
         //when
         ResultActions result = this.mockMvc.perform(
                 multipart("/api/users/img")
-                        .file(mockFile)
+                        .file(multipartFile)
                         .with(request -> {
                             request.setMethod("PATCH");
                             return request;

--- a/back/src/test/java/com/ogjg/back/user/service/UserServiceIntegrationTest.java
+++ b/back/src/test/java/com/ogjg/back/user/service/UserServiceIntegrationTest.java
@@ -29,7 +29,7 @@ public class UserServiceIntegrationTest {
                 .email("ogjg1234@naver.com")
                 .password("1q2w3e4r!")
                 .name("김회원")
-                .userImg("temp_url : {bucket-name}.s3.{region-code}.amazonaws.com/ogjg1234@naver.com/{fileName}")
+                .userImg("https://{bucket}.{region}.amazonaws.com/ogjg1234@naver.com/originFilename")
                 .userStatus(UserStatus.ACTIVE)
                 .build();
     }

--- a/back/src/test/java/com/ogjg/back/user/service/UserServiceTest.java
+++ b/back/src/test/java/com/ogjg/back/user/service/UserServiceTest.java
@@ -1,2 +1,58 @@
-package com.ogjg.back.user.service;public class UserServiceTest {
+package com.ogjg.back.user.service;
+
+import com.ogjg.back.s3.service.S3ProfileImageService;
+import com.ogjg.back.user.domain.User;
+import com.ogjg.back.user.dto.response.ImgUpdateResponse;
+import com.ogjg.back.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private S3ProfileImageService s3ProfileImageService;
+
+    @DisplayName("S3에 이미지 업로드 후 url 반환하는지 확인")
+    @Test
+    public void updateImg() throws Exception {
+        //given
+        String originFilename = "filename.jpg";
+        String loginEmail = "ogjg1234@naver.com";
+        String url = "https://{bucket}.{region}.amazonaws.com/"+loginEmail+"/"+originFilename;
+
+        User mockUser = mock(User.class);
+        MockMultipartFile multipartFile = new MockMultipartFile("img", originFilename, "image/jpeg", "image content".getBytes());
+        User updatedUser = User.builder()
+                .userImg(url)
+                .build();
+
+        given(userRepository.findByEmail(loginEmail))
+                .willReturn(Optional.of(mockUser));
+        given(s3ProfileImageService.saveImage(any(MultipartFile.class), any(String.class)))
+                .willReturn(url);
+        given(mockUser.updateImg(url))
+                .willReturn(updatedUser);
+
+        //when
+        ImgUpdateResponse response = userService.updateImg(multipartFile, loginEmail);
+
+        //then
+        assertThat(response.getUrl()).isEqualTo(url);
+    }
 }

--- a/back/src/test/java/com/ogjg/back/user/service/UserServiceTest.java
+++ b/back/src/test/java/com/ogjg/back/user/service/UserServiceTest.java
@@ -1,0 +1,2 @@
+package com.ogjg.back.user.service;public class UserServiceTest {
+}


### PR DESCRIPTION
###  Feat : OW-61 회원 프로필 이미지를 S3에 업로드하는 로직 추가
- [x] build.gradle aws-java-sdk 의존성 추가
- [x] 업로드 실패 시 S3ImageUploadException 발생, 에러코드 추가
- [x] @RequestParam으로 MultipartFile을 바인딩하도록 구현
- [x] User 엔티티 불필요한 메서드 제거
- [x] fileName -> filename으로 수정

 aws sdk를 활용해서 'image.'를 prefix로 검색해서 기존 프로필 이미지 삭제 후 업로드하도록 구현했습니다.
  - ❗️경로에 '.'을 포함해서 prefix를 사용해서 삭제하는 방식입니다. 프로젝트 폴더와 같은 디렉토리(prefix)안에 해당 프로필 이미지가 존재하기 때문에 폴더 경로에 '.'이 들어가서는 안됩니다.
- S3Repository와 S3ProfileImageService 생성하여 책임 분리했습니다. 
- S3ProfileImageService를 다른 서비스에서 주입받아 사용합니다.

### Test : OW-61 회원 프로필 이미지 S3 업로드 테스트 추가 및 수정 

### Feat : OW-61 최신 버전으로 의존성 수정, 회원 프로필 이미지 S3 업로드 로직 리팩토링
- [x] gradle 의존성 2.x 버전으로 변경
- [x] AmazonS3Client 대신 S3Client를 사용하도록 변경
- [x] delete 로직에 stream 사용
- [x] batch로 삭제하는 로직 추가