### PR TITLE
Feat : OW-62 컨테이너 생성 시 디렉토리를 S3에 업로드하는 로직 추가

### DIFF
--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     EMAIL_AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "이메일 인증에 실패 했습니다"),
     DUPLICATED_CONTAINER_NAME(HttpStatus.BAD_REQUEST, "400", "이미 존재하는 컨테이너 이름입니다"),
     INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "400", "현재 비밀번호 불일치"),
+    S3_FAIL_TO_UPLOAD_CONTAINER(HttpStatus.BAD_REQUEST, "400", "S3에 컨테이너 초기파일 업로드를 실패했습니다."),
     S3_FAIL_TO_UPLOAD_IMAGE(HttpStatus.BAD_REQUEST, "400", "S3에 프로필 이미지 업로드를 실패했습니다.");
 
     @JsonIgnore

--- a/back/src/main/java/com/ogjg/back/container/domain/Container.java
+++ b/back/src/main/java/com/ogjg/back/container/domain/Container.java
@@ -2,7 +2,9 @@ package com.ogjg.back.container.domain;
 
 import com.ogjg.back.user.domain.User;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
@@ -11,6 +13,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = PROTECTED)
 public class Container {
 
@@ -22,6 +25,8 @@ public class Container {
     @JoinColumn(name = "email")
     private User user;
 
+    @Pattern(regexp = "^[a-zA-Z0-9\\-_]{1,20}$",
+            message = "컨테이너 이름에는 영문, 숫자가 포함가능하며, 특수문자는 '-', '_'만 포함될 수 있습니다.")
     private String name;
 
     private String description;

--- a/back/src/main/java/com/ogjg/back/container/dto/request/ContainerCreateRequest.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/request/ContainerCreateRequest.java
@@ -2,6 +2,7 @@ package com.ogjg.back.container.dto.request;
 
 import com.ogjg.back.container.domain.Container;
 import com.ogjg.back.user.domain.User;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,9 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 public class ContainerCreateRequest {
+
+    @Pattern(regexp = "^[a-zA-Z0-9\\-_]{1,20}$",
+            message = "컨테이너 이름에는 영문, 숫자가 포함가능하며, 특수문자는 '-', '_'만 포함될 수 있습니다.")
     private String name;
     private String description;
     private boolean isPrivate;

--- a/back/src/main/java/com/ogjg/back/container/service/ContainerService.java
+++ b/back/src/main/java/com/ogjg/back/container/service/ContainerService.java
@@ -29,11 +29,9 @@ public class ContainerService {
         }
 
         Container container = request.toContainer(user);
-
-        // todo: s3에 컨테이너 생성
-        // todo: 필요하다면 디렉토리 구조 db에 반영
-
         containerRepository.save(container);
+
+        // todo: 필요하다면 디렉토리 구조 db에 반영
     }
 
     @Transactional(readOnly = true)

--- a/back/src/main/java/com/ogjg/back/s3/exception/S3ContainerUploadException.java
+++ b/back/src/main/java/com/ogjg/back/s3/exception/S3ContainerUploadException.java
@@ -1,0 +1,19 @@
+package com.ogjg.back.s3.exception;
+
+import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorData;
+
+public class S3ContainerUploadException extends CustomException {
+    public S3ContainerUploadException() {
+        super(ErrorCode.S3_FAIL_TO_UPLOAD_CONTAINER);
+    }
+
+    public S3ContainerUploadException(String message) {
+        super(ErrorCode.S3_FAIL_TO_UPLOAD_CONTAINER, message);
+    }
+
+    public S3ContainerUploadException(ErrorData errorData) {
+        super(ErrorCode.S3_FAIL_TO_UPLOAD_CONTAINER, errorData);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3ContainerRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3ContainerRepository.java
@@ -1,0 +1,52 @@
+package com.ogjg.back.s3.repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.util.Optional;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class S3ContainerRepository {
+    @Value("${cloud.aws.credentials.bucket-name}")
+    private String bucketName;
+    private final S3Client s3Client;
+
+    public Optional<String> uploadDirectory(String directoryName) {
+        String accessUrl = null;
+        try {
+            PutObjectRequest putObjRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(directoryName)
+                    .build();
+
+            s3Client.putObject(putObjRequest,
+                    RequestBody.fromString(directoryName));
+
+            accessUrl = getUrl(directoryName);
+            log.info("accessUrl={}", accessUrl);
+
+        } catch (Exception e) {
+            log.error("error message={}", e.getMessage());
+        }
+
+        return Optional.of(accessUrl);
+    }
+
+    private String getUrl(String fileName) {
+        GetUrlRequest getUrlRequest = GetUrlRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .build();
+
+        return s3Client.utilities()
+                .getUrl(getUrlRequest).toString();
+    }
+}

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3ImageUploadRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3ImageUploadRepository.java
@@ -14,7 +14,7 @@ import java.util.*;
 @Slf4j
 @Repository
 @RequiredArgsConstructor
-public class S3Repository {
+public class S3ImageUploadRepository {
 
     @Value("${cloud.aws.credentials.bucket-name}")
     private String bucketName;
@@ -23,12 +23,9 @@ public class S3Repository {
     public Optional<String> uploadFile(MultipartFile file, String filename) {
         String accessUrl = null;
         try {
-            Map<String, String> metadata = new HashMap<>();
-            metadata.put("x-amz-meta-myVal", "test");
             PutObjectRequest putObjRequest = PutObjectRequest.builder()
                     .bucket(bucketName)
                     .key(filename)
-                    .metadata(metadata)
                     .build();
 
             s3Client.putObject(putObjRequest,

--- a/back/src/main/java/com/ogjg/back/s3/service/S3ContainerService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3ContainerService.java
@@ -1,0 +1,22 @@
+package com.ogjg.back.s3.service;
+
+import com.ogjg.back.s3.exception.S3ContainerUploadException;
+import com.ogjg.back.s3.repository.S3ContainerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3ContainerService {
+
+    private final S3ContainerRepository s3ContainerRepository;
+
+    @Transactional
+    public String createContainer(String directory) {
+        return s3ContainerRepository.uploadDirectory(directory)
+                .orElseThrow(() -> new S3ContainerUploadException());
+    }
+}

--- a/back/src/main/java/com/ogjg/back/s3/service/S3ProfileImageService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3ProfileImageService.java
@@ -1,7 +1,7 @@
 package com.ogjg.back.s3.service;
 
 import com.ogjg.back.s3.exception.S3ImageUploadException;
-import com.ogjg.back.s3.repository.S3Repository;
+import com.ogjg.back.s3.repository.S3ImageUploadRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -12,7 +12,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @RequiredArgsConstructor
 public class S3ProfileImageService {
-    private final S3Repository s3Repository;
+    private final S3ImageUploadRepository s3ImageUploadRepository;
 
     /**
      * 기존에 존재하는 프로필 이미지를 삭제하고, 새 이미지를 저장한다.
@@ -23,11 +23,11 @@ public class S3ProfileImageService {
 
         // 컨테이너 이름에 . 을 넣을수 없다. image. 을 prefix로 이미지를 지우고 다시 생성한다.
         String prefix = email + "/image.";
-        s3Repository.deleteObjectsWithPrefix(prefix);
+        s3ImageUploadRepository.deleteObjectsWithPrefix(prefix);
 
         String fileName = prefix + extractExtension(originalName);
 
-        return s3Repository.uploadFile(multipartFile, fileName)
+        return s3ImageUploadRepository.uploadFile(multipartFile, fileName)
                 .orElseThrow(() -> new S3ImageUploadException());
     }
 


### PR DESCRIPTION
- [x] 디렉토리(String) s3 업로드 로직 추가
  - 이메일과 컨테이너 이름 기준으로 s3에 디렉토리를 생성하는 로직을 구현했으나, 추가할 파일 내용이 아직 없어서 현재는 사용하지 않는다.
  - 언어별 어떤 디렉토리를 업로드할 것인지 정해지지 않았다.
- [x] 테스트용 메타데이터 생성 로직 삭제
- [x] todo 주석 추가
- [x] container 업로드 실패 예외 및 에러코드 생성
- [x] container엔티티와 ContainerCreateRequest의 name 필드에 정규표현식 추가
- [x] S3Repository를 Service 별로 분리