### PR TITLE
fix : deploy 중단 에러 수정

### DIFF
--- a/.github/workflows/backend_cicd.yml
+++ b/.github/workflows/backend_cicd.yml
@@ -81,3 +81,5 @@ jobs:
           version_label: OGJG_Deploy-${{ github.SHA }}
           region: ${{ secrets.BACK_AWS_REGION }}
           deployment_package: deployment.zip
+          use_existing_version_if_available: true
+          wait_for_environment_recovery: 180


### PR DESCRIPTION
- 같은 라벨의 배포 버전이 있을 경우, 현재 배포되는 버전을 사용하도록 설정
- 네트워크 문제로 상태 확인이 늦는 경우 배포가 중단되지 않도록 대기 시간을 높게 설정