### PR TITLE
Feat : OW - 64 컨테이너 모든 구조 가져오기 기능 구현

### DIFF
--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "401", "아이디와 비밀번호를 확인 해주세요"),
     FAIL_SIGNUP(HttpStatus.BAD_REQUEST, "400", "회원가입에 실패 했습니다"),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "404", "회원를 찾을 수 없습니다"),
+    NOT_FOUND_CONTAINER(HttpStatus.NOT_FOUND, "400", "컨테이너를 찾을 수 없습니다"),
     INVALID_FORMAT(HttpStatus.BAD_REQUEST, "400", "데이터 검증 실패"),
     AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "인증에 실패 했습니다"),
     EMAIL_AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "이메일 인증에 실패 했습니다"),

--- a/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
+++ b/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
@@ -1,0 +1,25 @@
+package com.ogjg.back.common.util;
+
+public class S3PathUtil {
+
+    public static final String DELIMITER = "/";
+    public static final char S3_DELIMETER = '-';
+
+    /**
+     * email을 s3 prefix로 사용하기 위해 특수문자를 '-'로 대체한다.
+     */
+    public static String createS3Directory(String loginEmail, String containerName) {
+        return (DELIMITER + loginEmail + DELIMITER + containerName + DELIMITER)
+                .replace('.', S3_DELIMETER)
+                .replace('@', S3_DELIMETER);
+    }
+
+    /**
+     * s3 key에서 email 부분을 지운 경로를 반환한다.
+     * - s3에 회원별로 자신의 이메일을 이름으로 하는 루트 디렉토리를 가지고, 그 내부에 컨테이너마다 디렉토리가 생성된다.
+     * - 사용자는 주로 컨테이너 단위로 서비스를 이용해서 email을 제거한다.
+     */
+    public static String createEmailRemovedKey(String key, String email) {
+        return key.substring(email.length() + 1); // "/이메일" 을 제외한 디렉토리
+    }
+}

--- a/back/src/main/java/com/ogjg/back/container/controller/ContainerController.java
+++ b/back/src/main/java/com/ogjg/back/container/controller/ContainerController.java
@@ -3,7 +3,8 @@ package com.ogjg.back.container.controller;
 import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.response.ApiResponse;
 import com.ogjg.back.container.dto.request.ContainerCreateRequest;
-import com.ogjg.back.container.dto.response.ContainerNameCheckResponse;
+import com.ogjg.back.container.dto.response.ContainerCheckNameResponse;
+import com.ogjg.back.container.dto.response.ContainerGetResponse;
 import com.ogjg.back.container.service.ContainerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -30,7 +31,7 @@ public class ContainerController {
      * 컨테이너 이름 중복체크
      */
     @GetMapping("/check")
-    public ApiResponse<ContainerNameCheckResponse> checkDuplication(
+    public ApiResponse<ContainerCheckNameResponse> checkDuplication(
             @RequestParam("name") String containerName
     ) {
         String loginEmail = "ogjg1234@naver.com";
@@ -38,6 +39,21 @@ public class ContainerController {
         return new ApiResponse<>(
                 ErrorCode.SUCCESS,
                 containerService.checkDuplication(containerName, loginEmail)
+        );
+    }
+
+    /**
+     * 컨테이너 모든 구조 가져오기
+     */
+    @GetMapping("/{containerId}")
+    public ApiResponse<ContainerGetResponse> getContainer(
+            @PathVariable("containerId") Long containerId
+    ) {
+        String loginEmail = "ogjg1234@naver.com";
+
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS,
+                containerService.getAllFilesAndDirectories(containerId, loginEmail)
         );
     }
 }

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainerCheckNameResponse.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainerCheckNameResponse.java
@@ -8,16 +8,16 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class ContainerNameCheckResponse {
+public class ContainerCheckNameResponse {
     boolean isDuplicated;
 
     @Builder
-    public ContainerNameCheckResponse(boolean isDuplicated) {
+    public ContainerCheckNameResponse(boolean isDuplicated) {
         this.isDuplicated = isDuplicated;
     }
 
-    public static ContainerNameCheckResponse of(boolean isDuplicated) {
-        return ContainerNameCheckResponse.builder()
+    public static ContainerCheckNameResponse of(boolean isDuplicated) {
+        return ContainerCheckNameResponse.builder()
                 .isDuplicated(isDuplicated)
                 .build();
     }

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainerGetFileResponse.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainerGetFileResponse.java
@@ -1,0 +1,20 @@
+package com.ogjg.back.container.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ContainerGetFileResponse {
+    private String filePath;
+    private String content;
+
+    @Builder
+    public ContainerGetFileResponse(String filePath, String content) {
+        this.filePath = filePath;
+        this.content = content;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainerGetNodeResponse.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainerGetNodeResponse.java
@@ -1,0 +1,61 @@
+package com.ogjg.back.container.dto.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@JsonSerialize(using = ContainerNodeResponseSerializer.class)
+public class ContainerGetNodeResponse {
+    public static final String DELIMITER = "/";
+    private String key;
+    private String title;
+    private List<ContainerGetNodeResponse> children;
+
+    public ContainerGetNodeResponse(String key, String title) {
+        this.key = key;
+        this.title = title;
+        this.children = new ArrayList<>();
+    }
+
+    public ContainerGetNodeResponse findOrCreateChild(String fullKey, String title) {
+        for (ContainerGetNodeResponse child : children) {
+            if (child.title.equals(title)) {
+                return child;
+            }
+        }
+        ContainerGetNodeResponse newNode = new ContainerGetNodeResponse(fullKey, title);
+        children.add(newNode);
+        return newNode;
+    }
+
+    public static ContainerGetNodeResponse buildTreeFromKeys(List<String> s3Keys) {
+        ContainerGetNodeResponse root = new ContainerGetNodeResponse("", "root");
+
+        for (String fullKey : s3Keys) {
+            String[] parts = fullKey.split(DELIMITER);
+            ContainerGetNodeResponse currentNode = root;
+
+            // email, continerId 부분을 제외하고 파싱하기 위해 2부터 시작
+            for (int i = 2; i < parts.length; i++) {
+                String part = parts[i];
+                if (part.isEmpty()) continue;
+
+                String accumulatedKey = DELIMITER + String.join(DELIMITER, java.util.Arrays.copyOfRange(parts, 2, i + 1)) + DELIMITER;
+
+                currentNode = currentNode.findOrCreateChild(accumulatedKey, part);
+            }
+        }
+
+        return root.children.get(0);
+    }
+}
+
+
+

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainerGetResponse.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainerGetResponse.java
@@ -1,0 +1,32 @@
+package com.ogjg.back.container.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ContainerGetResponse {
+
+    private String language;
+    private ContainerGetNodeResponse treeData;
+    private List<ContainerGetFileResponse> fileData;
+    private List<String> directories;
+
+    @Builder
+    public ContainerGetResponse(
+            String language,
+            ContainerGetNodeResponse treeData,
+            List<ContainerGetFileResponse> fileData,
+            List<String> directories
+    ) {
+        this.language = language;
+        this.treeData = treeData;
+        this.fileData = fileData;
+        this.directories = directories;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainerNodeResponse.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainerNodeResponse.java
@@ -1,0 +1,60 @@
+package com.ogjg.back.container.dto.response;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@JsonSerialize(using = ContainerNodeResponseSerializer.class)
+public class ContainerNodeResponse {
+    public static final String DELIMITER_SLASH = "/";
+    private String key;
+    private String title;
+    private List<ContainerNodeResponse> children;
+
+    public ContainerNodeResponse(String key, String title) {
+        this.key = key;
+        this.title = title;
+        this.children = new ArrayList<>();
+    }
+
+    public ContainerNodeResponse findOrCreateChild(String fullKey, String title) {
+        for (ContainerNodeResponse child : children) {
+            if (child.title.equals(title)) {
+                return child;
+            }
+        }
+        ContainerNodeResponse newNode = new ContainerNodeResponse(fullKey, title);
+        children.add(newNode);
+        return newNode;
+    }
+
+    public static ContainerNodeResponse buildTreeFromS3Keys(List<String> s3Keys) {
+        ContainerNodeResponse root = new ContainerNodeResponse("", "Root");
+
+        for (String fullKey : s3Keys) {
+            String[] parts = fullKey.split(DELIMITER_SLASH);
+            ContainerNodeResponse currentNode = root;
+
+            for (int i = 0; i < parts.length; i++) {
+                String part = parts[i];
+                if (part.isEmpty()) continue;
+
+                String accumulatedKey = String.join(DELIMITER_SLASH, java.util.Arrays.copyOfRange(parts, 0, i + 1)) + DELIMITER_SLASH;
+
+                currentNode = currentNode.findOrCreateChild(accumulatedKey, part);
+            }
+        }
+
+        return root;
+    }
+}
+
+
+

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainerNodeResponseSerializer.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainerNodeResponseSerializer.java
@@ -1,0 +1,37 @@
+package com.ogjg.back.container.dto.response;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+import java.io.IOException;
+
+public class ContainerNodeResponseSerializer extends JsonSerializer<ContainerGetNodeResponse> {
+
+    @Override
+    public void serialize(ContainerGetNodeResponse value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeStartObject();
+
+        gen.writeStringField("key", value.getKey());
+        gen.writeStringField("title", value.getTitle());
+
+        // children 필드 값의 조건에 따라 직렬화 로직 변경
+        if (!isFile(value.getKey())) {
+            gen.writeFieldName("children");
+            gen.writeStartArray();
+
+            for (ContainerGetNodeResponse child : value.getChildren()) {
+                gen.writeObject(child);
+            }
+            gen.writeEndArray();
+        }
+
+        gen.writeEndObject();
+    }
+
+    private static boolean isFile(String key) {
+        String[] split = key.split("/");
+        return split[split.length-1].contains(".");
+    }
+}
+

--- a/back/src/main/java/com/ogjg/back/container/exception/NotFoundContainer.java
+++ b/back/src/main/java/com/ogjg/back/container/exception/NotFoundContainer.java
@@ -1,0 +1,19 @@
+package com.ogjg.back.container.exception;
+
+import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorData;
+
+public class NotFoundContainer extends CustomException {
+    public NotFoundContainer() {
+        super(ErrorCode.NOT_FOUND_CONTAINER);
+    }
+
+    public NotFoundContainer(String message) {
+        super(ErrorCode.NOT_FOUND_CONTAINER, message);
+    }
+
+    public NotFoundContainer(ErrorData errorData) {
+        super(ErrorCode.NOT_FOUND_CONTAINER, errorData);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/container/service/ContainerService.java
+++ b/back/src/main/java/com/ogjg/back/container/service/ContainerService.java
@@ -2,21 +2,31 @@ package com.ogjg.back.container.service;
 
 import com.ogjg.back.container.domain.Container;
 import com.ogjg.back.container.dto.request.ContainerCreateRequest;
-import com.ogjg.back.container.dto.response.ContainerNameCheckResponse;
+import com.ogjg.back.container.dto.response.ContainerCheckNameResponse;
+import com.ogjg.back.container.dto.response.ContainerGetResponse;
 import com.ogjg.back.container.exception.DuplicatedContainerName;
+import com.ogjg.back.container.exception.NotFoundContainer;
 import com.ogjg.back.container.repository.ContainerRepository;
+import com.ogjg.back.s3.service.S3ContainerService;
 import com.ogjg.back.user.domain.User;
 import com.ogjg.back.user.exception.NotFoundUser;
 import com.ogjg.back.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
+import static com.ogjg.back.common.util.S3PathUtil.createEmailRemovedKey;
+import static com.ogjg.back.common.util.S3PathUtil.createS3Directory;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ContainerService {
-
     private final ContainerRepository containerRepository;
+    private final S3ContainerService s3ContainerService;
     private final UserRepository userRepository;
 
     @Transactional
@@ -24,25 +34,60 @@ public class ContainerService {
         User user = userRepository.findByEmail(loginEmail)
                 .orElseThrow(() -> new NotFoundUser());
 
-        if (isDuplicated(request.getName(), loginEmail)) {
+        if (isContainerNameDuplicated(request.getName(), loginEmail)) {
             throw new DuplicatedContainerName();
         }
+
+        // todo: 언어별 디렉토리 내려주기
+        // s3에 명시적으로 빈 경로 데이터를 만들어줘야 후에 listObject로 조회가 가능하다.
+        s3ContainerService.createContainer(
+                createS3Directory(loginEmail, request.getName())
+        );
 
         Container container = request.toContainer(user);
         containerRepository.save(container);
 
-        // todo: 필요하다면 디렉토리 구조 db에 반영
+        // todo: 디렉토리 구조 db에 반영
+    }
+
+    protected boolean isContainerNameDuplicated(String containerName, String loginEmail) {
+        return containerRepository.findByNameAndEmail(containerName, loginEmail)
+                .isPresent();
     }
 
     @Transactional(readOnly = true)
-    public ContainerNameCheckResponse checkDuplication(String containerName, String loginEmail) {
-        return ContainerNameCheckResponse.of(
-                isDuplicated(containerName, loginEmail)
+    public ContainerCheckNameResponse checkDuplication(String containerName, String loginEmail) {
+        return ContainerCheckNameResponse.of(
+                isContainerNameDuplicated(containerName, loginEmail)
         );
     }
 
-    protected boolean isDuplicated(String containerName, String loginEmail) {
-       return containerRepository.findByNameAndEmail(containerName, loginEmail)
-                .isPresent();
+    @Transactional
+    public ContainerGetResponse getAllFilesAndDirectories(Long containerId, String loginEmail) {
+        Container container = containerRepository.findById(containerId)
+                .orElseThrow(() -> new NotFoundContainer());
+
+        String prefix = createS3Directory(loginEmail, container.getName());
+        List<String> allKeys = s3ContainerService.getAllKeysByPrefix(prefix);
+
+        for (String key : allKeys) {
+            log.debug("key ={}", key);
+        }
+
+        // 맨 앞에 이메일 부분이 절삭된 key 목록을 만든다.
+        List<String> parsedKeys = parse(allKeys, loginEmail);
+
+        return ContainerGetResponse.builder()
+                .language(container.getLanguage())
+                .treeData(s3ContainerService.buildTreeFromKeys(parsedKeys))
+                .fileData(s3ContainerService.getFileData(allKeys, loginEmail))
+                .directories(s3ContainerService.getDirectories(parsedKeys))
+                .build();
+    }
+
+    private List<String> parse(List<String> allKeys, String email) {
+        return allKeys.stream()
+                .map((key) -> createEmailRemovedKey(key, email))
+                .toList();
     }
 }

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3ContainerRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3ContainerRepository.java
@@ -5,10 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Repository;
 import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.GetUrlRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.*;
 
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -22,12 +23,12 @@ public class S3ContainerRepository {
     public Optional<String> uploadDirectory(String directoryName) {
         String accessUrl = null;
         try {
-            PutObjectRequest putObjRequest = PutObjectRequest.builder()
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucketName)
                     .key(directoryName)
                     .build();
 
-            s3Client.putObject(putObjRequest,
+            s3Client.putObject(putObjectRequest,
                     RequestBody.fromString(directoryName));
 
             accessUrl = getUrl(directoryName);
@@ -48,5 +49,23 @@ public class S3ContainerRepository {
 
         return s3Client.utilities()
                 .getUrl(getUrlRequest).toString();
+    }
+
+    public List<S3Object> getAllObjectsByPrefix(String prefix) {
+        ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder()
+                .bucket(bucketName)
+                .prefix(prefix)
+                .build();
+
+        return s3Client.listObjectsV2(listObjectsV2Request).contents();
+    }
+
+    public String getFileContent(String key) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(key)
+                .build();
+
+        return s3Client.getObject(getObjectRequest, ResponseTransformer.toBytes()).asUtf8String();
     }
 }

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3ImageUploadRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3ImageUploadRepository.java
@@ -23,12 +23,12 @@ public class S3ImageUploadRepository {
     public Optional<String> uploadFile(MultipartFile file, String filename) {
         String accessUrl = null;
         try {
-            PutObjectRequest putObjRequest = PutObjectRequest.builder()
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucketName)
                     .key(filename)
                     .build();
 
-            s3Client.putObject(putObjRequest,
+            s3Client.putObject(putObjectRequest,
                     RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
 
             accessUrl = getUrl(filename);

--- a/back/src/main/java/com/ogjg/back/s3/service/S3ContainerService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3ContainerService.java
@@ -1,11 +1,17 @@
 package com.ogjg.back.s3.service;
 
+import com.ogjg.back.container.dto.response.ContainerGetFileResponse;
+import com.ogjg.back.container.dto.response.ContainerGetNodeResponse;
 import com.ogjg.back.s3.exception.S3ContainerUploadException;
 import com.ogjg.back.s3.repository.S3ContainerRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.ogjg.back.common.util.S3PathUtil.createEmailRemovedKey;
 
 @Slf4j
 @Service
@@ -18,5 +24,65 @@ public class S3ContainerService {
     public String createContainer(String directory) {
         return s3ContainerRepository.uploadDirectory(directory)
                 .orElseThrow(() -> new S3ContainerUploadException());
+    }
+
+    @Transactional(readOnly = true)
+    public List<String> getAllKeysByPrefix(String prefix) {
+        return s3ContainerRepository.getAllObjectsByPrefix(prefix).stream()
+                .map((s3Object) -> s3Object.key())
+                .toList();
+    }
+
+    /**
+     * 컨테이너 모든 구조 가져오기 - treeData 생성
+     * 이메일 경로를 제외한 구조를 응답값에 포함해야 하므로 절삭된 키 사용
+     */
+    @Transactional(readOnly = true)
+    public ContainerGetNodeResponse buildTreeFromKeys(List<String> parsedKeys) {
+        return ContainerGetNodeResponse.buildTreeFromKeys(parsedKeys);
+    }
+
+    /**
+     * 컨테이너 모든 구조 가져오기 - fileData 생성
+     * 전체 경로인 키로 조회해서 데이터를 가져와야해서 원래 키로 조회
+     */
+    @Transactional(readOnly = true)
+    public List<ContainerGetFileResponse> getFileData(List<String> allKeys, String email) {
+        // 전체 키에서 파일인 것만 추출
+        List<String> fileKeys = allKeys.stream()
+                .filter((key) -> isFile(key))
+                .toList();
+
+        // s3에서 키에 해당하는 모든 [파일이름-데이터] 받아오기
+        List<ContainerGetFileResponse> fileData = createFileResponse(fileKeys, email);
+        return fileData;
+    }
+
+    private static boolean isFile(String key) {
+        return key.contains(".");
+    }
+
+    // todo: 병렬처리 등 요청수 줄일 방법 고려하기
+    private List<ContainerGetFileResponse> createFileResponse(List<String> keys, String email) {
+        return keys.stream()
+                .map((key) -> toFileResponse(key, email))
+                .toList();
+    }
+
+    private ContainerGetFileResponse toFileResponse(String key, String email) {
+        return ContainerGetFileResponse.builder()
+                .filePath(createEmailRemovedKey(key, email))
+                .content(s3ContainerRepository.getFileContent(key))
+                .build();
+    }
+
+    /**
+     * 컨테이너 모든 구조 가져오기 - 디렉토리 데이터 생성
+     * 이메일 경로를 제외한 구조를 응답값에 포함해야 하므로 절삭된 키 사용
+     */
+    public List<String> getDirectories(List<String> parsedKeys) {
+        return parsedKeys.stream()
+                .filter((key) -> !isFile(key))
+                .toList();
     }
 }


### PR DESCRIPTION
- [x] s3의 listObjects, getObject를 활용해서 모든 구조를  조회는 기능 구현
  - prefix로 목록을 조회 후 키 개수만큼 getObject를 사용해서 모든 데이터를 조회
- [x]  S3ContainerService, S3ContainerRepository 생성
- [x] 컨테이너의 모든 구조를 전달하는 ContainerGetResponse 구현 
  - treeData : 전체 목록을 트리 형태로 파싱한 데이터
  - fileData : 모든 파일에 대해서만 (파일 경로-데이터) 형태로 저장된 List 
  - directories : rename시 체크를 위한 데이터로 모든 디렉토리의 이름을 가진 List
- [x] ContainerNodeResponse에 커스텀 직렬화 적용
  - ContainerNodeResponseSerializer 클래스 생성 및 커스텀
  - 파일인 경우 응답 json 데이터에 children 항목이 생기지 않도록 구현
- [x] 해당 컨테이너가 없는 경우에 대한 예외, 에러코드 구현
- [x] 변수명 Obj -> Object로 변경
- [x] s3 path 변환에 사용할 S3PathUtil 클래스 생성
- [x] 컨테이너 생성 로직 추가
  - 이전에 구현한 로직 3S 디렉토리 업로드하도록 추가
  - 명시적으로 빈 디렉토리를 업로드해야 listObjects로 조회 가능하다.
- [x] 누락된 기본 생성자 추가
- [x] 변수명 일부 수정
