### PR TITLE
Feat : 채팅 기능 구현

### DIFF
--- a/back/src/main/java/com/ogjg/back/chat/controller/MessageController.java
+++ b/back/src/main/java/com/ogjg/back/chat/controller/MessageController.java
@@ -1,0 +1,60 @@
+package com.ogjg.back.chat.controller;
+
+import com.ogjg.back.chat.domain.MessageType;
+import com.ogjg.back.chat.dto.ChattingRoomUserInfoDto;
+import com.ogjg.back.chat.dto.MessageDto;
+import com.ogjg.back.chat.service.MessageService;
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+@Slf4j
+public class MessageController {
+
+    private final MessageService messageService;
+
+    @MessageMapping("/chat/enter-room")
+    public void enterRoom(@Payload MessageDto message, SimpMessageHeaderAccessor headerAccessor) {
+
+        messageService.addUserInfoInSessionAttribute(message, headerAccessor);
+        messageService.saveUserRoom(message);
+
+        message.setType(MessageType.ENTER);
+        message.setContent(message.getSender() + "님이 입장하셨습니다.");
+
+        messageService.saveAndSendMessage(message);
+    }
+
+    @MessageMapping("/chat/send-message")
+    public void sendMessage(@Payload MessageDto message) {
+        messageService.saveAndSendMessage(message);
+    }
+
+    @GetMapping("/{containerId}/users")
+    public ApiResponse<?> getUsersInChattingRoom(@PathVariable Long containerId) {
+
+        List<ChattingRoomUserInfoDto> users = messageService.getUsersInChattingRoom(containerId);
+        return new ApiResponse<>(ErrorCode.SUCCESS, users);
+    }
+
+    @GetMapping("/{containerId}/messages")
+    public ApiResponse<?> getMessagesInChattingRoom(@PathVariable Long containerId) {
+
+        List<MessageDto> responseData = messageService.getMessagesInChattingRoom(containerId);
+        return new ApiResponse<>(ErrorCode.SUCCESS, responseData);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/chat/domain/Message.java
+++ b/back/src/main/java/com/ogjg/back/chat/domain/Message.java
@@ -1,0 +1,45 @@
+package com.ogjg.back.chat.domain;
+
+import com.ogjg.back.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Message {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    @ManyToOne
+    @JoinColumn(name = "email")
+    private User user;
+
+    private MessageType type;
+
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Builder
+    public Message(Room room, User user, MessageType type, String content) {
+        this.room = room;
+        this.user = user;
+        this.type = type;
+        this.content = content;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/chat/domain/MessageType.java
+++ b/back/src/main/java/com/ogjg/back/chat/domain/MessageType.java
@@ -1,0 +1,5 @@
+package com.ogjg.back.chat.domain;
+
+public enum MessageType {
+    ENTER, TALK, LEAVE
+}

--- a/back/src/main/java/com/ogjg/back/chat/domain/Room.java
+++ b/back/src/main/java/com/ogjg/back/chat/domain/Room.java
@@ -1,0 +1,30 @@
+package com.ogjg.back.chat.domain;
+
+import com.ogjg.back.container.domain.Container;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Room {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "container_id")
+    private Container container;
+
+    @Builder
+    public Room(Container container) {
+        this.container = container;
+    }
+}
+

--- a/back/src/main/java/com/ogjg/back/chat/domain/UserRoom.java
+++ b/back/src/main/java/com/ogjg/back/chat/domain/UserRoom.java
@@ -1,0 +1,39 @@
+package com.ogjg.back.chat.domain;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class UserRoom {
+
+    @EmbeddedId
+    private UserRoomPK id;
+
+    public UserRoom(UserRoomPK id) {
+        this.id = id;
+    }
+
+    @Embeddable
+    @NoArgsConstructor(access = PROTECTED)
+    @EqualsAndHashCode
+    @Getter
+    public static class UserRoomPK implements Serializable {
+        private String email;
+        private Long roomId;
+
+        public UserRoomPK(String email, Long roomId) {
+            this.email = email;
+            this.roomId = roomId;
+        }
+    }
+}

--- a/back/src/main/java/com/ogjg/back/chat/dto/ChattingRoomUserInfoDto.java
+++ b/back/src/main/java/com/ogjg/back/chat/dto/ChattingRoomUserInfoDto.java
@@ -1,0 +1,23 @@
+package com.ogjg.back.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ChattingRoomUserInfoDto {
+
+    private String email;
+    private String userImg;
+    private String userName;
+
+    @Builder
+    public ChattingRoomUserInfoDto(String email, String userImg, String userName) {
+        this.email = email;
+        this.userImg = userImg;
+        this.userName = userName;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/chat/dto/MessageDto.java
+++ b/back/src/main/java/com/ogjg/back/chat/dto/MessageDto.java
@@ -1,0 +1,27 @@
+package com.ogjg.back.chat.dto;
+
+import com.ogjg.back.chat.domain.MessageType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+public class MessageDto {
+
+    private MessageType type;
+    private String email;
+    private Long containerId;
+    private String sender;
+    private String content;
+
+    @Builder
+    public MessageDto(MessageType type, String email, Long containerId, String sender, String content) {
+        this.type = type;
+        this.email = email;
+        this.containerId = containerId;
+        this.sender = sender;
+        this.content = content;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/chat/repository/MessageRepository.java
+++ b/back/src/main/java/com/ogjg/back/chat/repository/MessageRepository.java
@@ -1,0 +1,13 @@
+package com.ogjg.back.chat.repository;
+
+import com.ogjg.back.chat.domain.Message;
+import com.ogjg.back.chat.domain.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MessageRepository extends JpaRepository<Message, Long> {
+
+    Optional<List<Message>> findAllByRoom(Room room);
+}

--- a/back/src/main/java/com/ogjg/back/chat/repository/RoomRepository.java
+++ b/back/src/main/java/com/ogjg/back/chat/repository/RoomRepository.java
@@ -1,0 +1,7 @@
+package com.ogjg.back.chat.repository;
+
+import com.ogjg.back.chat.domain.Room;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoomRepository extends JpaRepository<Room, Long> {
+}

--- a/back/src/main/java/com/ogjg/back/chat/repository/UserRoomRepository.java
+++ b/back/src/main/java/com/ogjg/back/chat/repository/UserRoomRepository.java
@@ -1,0 +1,15 @@
+package com.ogjg.back.chat.repository;
+
+import com.ogjg.back.chat.domain.UserRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.ogjg.back.chat.domain.UserRoom.UserRoomPK;
+
+public interface UserRoomRepository extends JpaRepository<UserRoom, UserRoomPK> {
+    Optional<List<UserRoom>> findById_Email(String email);
+
+    Optional<List<UserRoom>> findById_RoomId(Long roomId);
+}

--- a/back/src/main/java/com/ogjg/back/chat/service/MessageService.java
+++ b/back/src/main/java/com/ogjg/back/chat/service/MessageService.java
@@ -1,0 +1,163 @@
+package com.ogjg.back.chat.service;
+
+import com.ogjg.back.chat.domain.Message;
+import com.ogjg.back.chat.domain.MessageType;
+import com.ogjg.back.chat.domain.Room;
+import com.ogjg.back.chat.domain.UserRoom;
+import com.ogjg.back.chat.dto.ChattingRoomUserInfoDto;
+import com.ogjg.back.chat.dto.MessageDto;
+import com.ogjg.back.chat.repository.MessageRepository;
+import com.ogjg.back.chat.repository.RoomRepository;
+import com.ogjg.back.chat.repository.UserRoomRepository;
+import com.ogjg.back.container.domain.Container;
+import com.ogjg.back.container.repository.ContainerRepository;
+import com.ogjg.back.user.domain.User;
+import com.ogjg.back.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MessageService {
+
+    private final SimpMessageSendingOperations template;
+    private final MessageRepository messageRepository;
+    private final RoomRepository roomRepository;
+    private final UserRoomRepository userRoomRepository;
+    private final UserRepository userRepository;
+    private final ContainerRepository containerRepository;
+
+
+    @Transactional
+    public void saveUserRoom(MessageDto message) {
+        UserRoom.UserRoomPK userRoomPK = new UserRoom.UserRoomPK(message.getSender(), message.getContainerId());
+        UserRoom userRoom = new UserRoom(userRoomPK);
+        userRoomRepository.save(userRoom);
+    }
+
+    @Transactional
+    public void saveAndSendMessage(MessageDto message) {
+        saveMessage(message);
+        sendMessage(message);
+    }
+
+    private void saveMessage(MessageDto message) {
+        User user = userRepository.findByEmail(message.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
+        Container container = containerRepository.findById(message.getContainerId())
+                .orElseThrow(() -> new IllegalArgumentException("컨테이너가 존재하지 않습니다."));
+
+        Message chatMessage = Message.builder()
+                .room(new Room(container))
+                .user(user)
+                .type(message.getType())
+                .content(message.getContent())
+                .build();
+
+        messageRepository.save(chatMessage);
+    }
+
+    private void sendMessage(MessageDto message) {
+        template.convertAndSend("/sub/chat/room/" + message.getContainerId(), message.getContent());
+    }
+
+    public void addUserInfoInSessionAttribute(MessageDto message, SimpMessageHeaderAccessor headerAccessor) {
+        Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+        if (sessionAttributes == null) {
+            throw new IllegalArgumentException("STOMP SessionHeader Error.");
+        }
+        log.info("세션 정보: {}", sessionAttributes);
+        sessionAttributes.put("email", message.getEmail());
+        sessionAttributes.put("username", message.getSender());
+    }
+
+    @EventListener
+    @Transactional
+    public void handleWebSocketDisconnectListener(SessionDisconnectEvent event) {
+
+        StompHeaderAccessor headerAccessor = StompHeaderAccessor.wrap(event.getMessage());
+
+        Map<String, Object> sessionAttributes = headerAccessor.getSessionAttributes();
+        if (sessionAttributes == null) {
+            throw new IllegalArgumentException("STOMP SessionHeader Error.");
+        }
+
+        String email = (String) sessionAttributes.get("email");
+        String username = (String) sessionAttributes.get("username");
+
+        List<UserRoom> userRooms = userRoomRepository.findById_Email(email)
+                .orElseThrow(() -> new IllegalArgumentException("[이메일] 잘못된 접근입니다."));
+        log.info("UserRooms: {}", userRooms);
+        userRoomRepository.deleteAll(userRooms);
+
+        log.info("UserRooms: {}", userRooms);
+        String leaveMessage = username + "님이 퇴장하셨습니다.";
+        for (UserRoom userRoom : userRooms) {
+            MessageDto message = MessageDto.builder()
+                    .type(MessageType.LEAVE)
+                    .containerId(userRoom.getId().getRoomId())
+                    .email(email)
+                    .sender(username)
+                    .content(leaveMessage)
+                    .build();
+            template.convertAndSend("/sub/room/" + userRoom.getId().getRoomId(), message);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<ChattingRoomUserInfoDto> getUsersInChattingRoom(Long containerId) {
+
+        List<UserRoom> userRooms = userRoomRepository.findById_RoomId(containerId)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 컨테이너입니다."));
+
+        List<ChattingRoomUserInfoDto> users = new ArrayList<>();
+        for (UserRoom userRoom : userRooms) {
+            String email = userRoom.getId().getEmail();
+            User user = userRepository.findByEmail(email)
+                    .orElseThrow(() -> new IllegalArgumentException("잘못된 이메일입니다."));
+            ChattingRoomUserInfoDto userInfoDto = ChattingRoomUserInfoDto.builder()
+                    .email(user.getEmail())
+                    .userImg(user.getUserImg())
+                    .userName(user.getName())
+                    .build();
+            users.add(userInfoDto);
+        }
+
+        return users;
+    }
+
+    @Transactional(readOnly = true)
+    public List<MessageDto> getMessagesInChattingRoom(Long containerId) {
+
+        Room room = roomRepository.findById(containerId)
+                .orElseThrow(() -> new IllegalArgumentException("잘못된 컨테이너 요청입니다."));
+
+        Optional<List<Message>> messages = messageRepository.findAllByRoom(room);
+        if (messages.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return messages.orElseGet(ArrayList::new)
+                .stream()
+                .map(message -> MessageDto.builder()
+                        .type(message.getType())
+                        .email(message.getUser().getEmail())
+                        .sender(message.getUser().getName())
+                        .content(message.getContent())
+                        .build())
+                .toList();
+    }
+}

--- a/back/src/main/java/com/ogjg/back/config/WebsocketConfig.java
+++ b/back/src/main/java/com/ogjg/back/config/WebsocketConfig.java
@@ -1,0 +1,25 @@
+package com.ogjg.back.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@EnableWebSocketMessageBroker
+@Configuration
+public class WebsocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws/chat")
+                .setAllowedOrigins("https://ogjg.site")
+                .withSockJS();
+    }
+}

--- a/back/src/main/java/com/ogjg/back/config/security/config/SecurityConfig.java
+++ b/back/src/main/java/com/ogjg/back/config/security/config/SecurityConfig.java
@@ -27,7 +27,7 @@ import java.util.List;
 import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
-@EnableWebSecurity(debug = true)
+@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -41,7 +41,9 @@ public class SecurityConfig {
                     "/api/users/signup",
                     "/api/users/login",
                     "/api/users/find-password/.*",
-                    "/health"
+                    "/health",
+                    "/ws/.*",
+                    "/chat/.*"
             ));
 
 

--- a/back/src/main/java/com/ogjg/back/container/domain/Container.java
+++ b/back/src/main/java/com/ogjg/back/container/domain/Container.java
@@ -1,5 +1,6 @@
 package com.ogjg.back.container.domain;
 
+import com.ogjg.back.chat.domain.Room;
 import com.ogjg.back.user.domain.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Pattern;
@@ -27,6 +28,10 @@ public class Container {
 
     @Pattern(regexp = "^[a-zA-Z0-9\\-_]{1,20}$",
             message = "컨테이너 이름에는 영문, 숫자가 포함가능하며, 특수문자는 '-', '_'만 포함될 수 있습니다.")
+    @OneToOne
+    @JoinColumn(name = "room_id")
+    private Room room;
+
     private String name;
 
     private String description;


### PR DESCRIPTION
## 초기 설정
- Room, Message, UserRoom Entity, Repository 구현
- UserRoom은 채팅방에 접속 중인 사용자에 대한 매핑 테이블을 의미한다.
- 웹소켓 통신을 위한 WebsocketConfig 작성

## 채팅 기능 - 연결, 통신 로직 및 API 구현
### 채팅방 구독 로직
- 채팅방 최초 입장 시 해당 채팅방에 있는 유저에게 입장 메세지를 전송하도록 구현
- 현재 유저의 정보를 SessionAttribute에 저장하고, 실제 DB에도 메세지를 저장

### 채팅방 메시지 전송
- 참여중인 채팅방에 메시지를 전송하도록 구현

### 채팅방 유저 리스트 조회
- 현재 채팅방에 참여 중인 유저들을 반환

### 채팅방 퇴장
- 웹소켓의 연결이 끊어지면 작동하는 @eventlistener를 사용하여 구현
- 구독 시 저장했던 SessionAttribute의 내부 데이터로 식별하여 메시지를 전송하도록 작성