### PR TITLE
Feat : OW-65 파일 관리 API 구현

### DIFF
--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -84,3 +84,10 @@ include::{snippets}/file/create/request-fields.adoc[]
 
 include::{snippets}/file/create/http-response.adoc[]
 
+=== 파일 삭제
+해당 경로의 파일을 삭제합니다.
+
+include::{snippets}/file/delete/http-request.adoc[]
+include::{snippets}/file/delete/request-fields.adoc[]
+
+include::{snippets}/file/delete/http-response.adoc[]

--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -101,3 +101,10 @@ include::{snippets}/file/update/request-fields.adoc[]
 
 include::{snippets}/file/update/http-response.adoc[]
 
+=== 파일 이름 수정
+해당 경로의 파일의 이름을 수정합니다.
+
+include::{snippets}/file/rename/http-request.adoc[]
+include::{snippets}/file/rename/request-fields.adoc[]
+
+include::{snippets}/file/rename/http-response.adoc[]

--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -91,3 +91,13 @@ include::{snippets}/file/delete/http-request.adoc[]
 include::{snippets}/file/delete/request-fields.adoc[]
 
 include::{snippets}/file/delete/http-response.adoc[]
+include::{snippets}/file/delete/http-response.adoc[]
+
+=== 파일 수정
+해당 경로의 파일을 수정합니다.
+
+include::{snippets}/file/update/http-request.adoc[]
+include::{snippets}/file/update/request-fields.adoc[]
+
+include::{snippets}/file/update/http-response.adoc[]
+

--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -39,22 +39,28 @@ include::{snippets}/user/deactivate/http-response.adoc[]
 
 == 컨테이너 API
 
-=== API1
-api1
+=== 컨테이너 모든 구조 가져오기
+컨테이너(프로젝트)에 접근할때, 전체 디렉토리와 파일 정보를 모두 전달합니다.
 
-=== API2
-api2
+include::{snippets}/container/get/http-request.adoc[]
+include::{snippets}/container/get/path-parameters.adoc[]
 
+include::{snippets}/container/get/http-response.adoc[]
+include::{snippets}/container/get/response-fields.adoc[]
 
 == 컨테이너 생성 API
 
 === 컨테이너 생성
+컨테이너를 생성하면, 해당 디렉토리를 저장합니다.
+
 include::{snippets}/container/create/http-request.adoc[]
 include::{snippets}/container/create/request-fields.adoc[]
 
 include::{snippets}/container/create/http-response.adoc[]
 
 === 컨테이너 이름 중복체크
+컨테이너 생성 시에 중복되는 컨테이너 이름이 없는지 검사합니다.
+
 include::{snippets}/container/check/http-request.adoc[]
 include::{snippets}/container/check/query-parameters.adoc[]
 
@@ -66,3 +72,15 @@ include::{snippets}/container/get/path-parameters.adoc[]
 
 include::{snippets}/container/get/http-response.adoc[]
 include::{snippets}/container/get/response-fields.adoc[]
+include::{snippets}/container/check/http-response.adoc[]
+
+== 파일 API
+
+=== 파일 생성
+해당 경로의 파일을 생성합니다.
+
+include::{snippets}/file/create/http-request.adoc[]
+include::{snippets}/file/create/request-fields.adoc[]
+
+include::{snippets}/file/create/http-response.adoc[]
+

--- a/back/src/main/java/com/ogjg/back/BackApplication.java
+++ b/back/src/main/java/com/ogjg/back/BackApplication.java
@@ -9,5 +9,4 @@ public class BackApplication {
     public static void main(String[] args) {
         SpringApplication.run(BackApplication.class, args);
     }
-
 }

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -17,6 +17,8 @@ public enum ErrorCode {
     EMAIL_AUTH_FAIL(HttpStatus.UNAUTHORIZED, "401", "이메일 인증에 실패 했습니다"),
     DUPLICATED_CONTAINER_NAME(HttpStatus.BAD_REQUEST, "400", "이미 존재하는 컨테이너 이름입니다"),
     INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "400", "현재 비밀번호 불일치"),
+    S3_NOT_FOUND_FILE(HttpStatus.NOT_FOUND, "400", "S3에 존재하지 않는 파일입니다."),
+    S3_FILE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "400", "S3에 이미 존재하는 파일입니다."),
     S3_FAIL_TO_UPLOAD_CONTAINER(HttpStatus.BAD_REQUEST, "400", "S3에 컨테이너 초기파일 업로드를 실패했습니다."),
     S3_FAIL_TO_UPLOAD_IMAGE(HttpStatus.BAD_REQUEST, "400", "S3에 프로필 이미지 업로드를 실패했습니다.");
 

--- a/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
+++ b/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
@@ -9,9 +9,18 @@ public class S3PathUtil {
      * email을 s3 prefix로 사용하기 위해 특수문자를 '-'로 대체한다.
      */
     public static String createS3Directory(String loginEmail, String containerName) {
-        return (DELIMITER + loginEmail + DELIMITER + containerName + DELIMITER)
+        loginEmail = loginEmail
                 .replace('.', S3_DELIMETER)
                 .replace('@', S3_DELIMETER);
+        return (DELIMITER + loginEmail + DELIMITER + containerName + DELIMITER);
+
+    }
+
+    public static String createS3PathWithFilePath(String loginEmail, String filePath) {
+        loginEmail = loginEmail
+                .replace('.', S3_DELIMETER)
+                .replace('@', S3_DELIMETER);
+        return (DELIMITER + loginEmail + filePath);
     }
 
     /**
@@ -21,6 +30,10 @@ public class S3PathUtil {
      */
     public static String createEmailRemovedKey(String key, String email) {
         return key.substring(email.length() + 1); // "/이메일" 을 제외한 디렉토리
+    }
+
+    public static String extractContainerName(String filePath) {
+        return filePath.split(DELIMITER)[1]; // 경로 시작이 / 이므로 배열 첫 요소는 비어있다.
     }
 
     public static boolean isFile(String path) {

--- a/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
+++ b/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
@@ -3,23 +3,23 @@ package com.ogjg.back.common.util;
 public class S3PathUtil {
 
     public static final String DELIMITER = "/";
-    public static final char S3_DELIMETER = '-';
+    public static final char S3_EMAIL_DELIMETER = '-';
 
     /**
      * email을 s3 prefix로 사용하기 위해 특수문자를 '-'로 대체한다.
      */
     public static String createS3Directory(String loginEmail, String containerName) {
         loginEmail = loginEmail
-                .replace('.', S3_DELIMETER)
-                .replace('@', S3_DELIMETER);
+                .replace('.', S3_EMAIL_DELIMETER)
+                .replace('@', S3_EMAIL_DELIMETER);
         return (DELIMITER + loginEmail + DELIMITER + containerName + DELIMITER);
 
     }
 
     public static String createS3PathWithFilePath(String loginEmail, String filePath) {
         loginEmail = loginEmail
-                .replace('.', S3_DELIMETER)
-                .replace('@', S3_DELIMETER);
+                .replace('.', S3_EMAIL_DELIMETER)
+                .replace('@', S3_EMAIL_DELIMETER);
         return (DELIMITER + loginEmail + filePath);
     }
 
@@ -38,5 +38,10 @@ public class S3PathUtil {
 
     public static boolean isFile(String path) {
         return path.contains(".");
+    }
+
+    public static String createNewFilePath(String originPath, String newFilename) {
+        int lastDelimiterIndex = originPath.lastIndexOf(DELIMITER);
+        return originPath.substring(0, lastDelimiterIndex) + DELIMITER + newFilename;
     }
 }

--- a/back/src/main/java/com/ogjg/back/file/controller/FileController.java
+++ b/back/src/main/java/com/ogjg/back/file/controller/FileController.java
@@ -1,0 +1,27 @@
+package com.ogjg.back.file.controller;
+
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.response.ApiResponse;
+import com.ogjg.back.file.dto.request.CreateFileRequest;
+import com.ogjg.back.file.service.FileService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/files")
+public class FileController {
+
+    private final FileService fileService;
+
+    @PostMapping("")
+    public ApiResponse<Void> createFile(
+            @RequestBody CreateFileRequest request
+    ) {
+        String loginEmail = "ogjg1234@naver.com";
+        fileService.createFile(loginEmail, request);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/file/controller/FileController.java
+++ b/back/src/main/java/com/ogjg/back/file/controller/FileController.java
@@ -4,6 +4,7 @@ import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.response.ApiResponse;
 import com.ogjg.back.file.dto.request.CreateFileRequest;
 import com.ogjg.back.file.dto.request.DeleteFileRequest;
+import com.ogjg.back.file.dto.request.UpdateFileRequest;
 import com.ogjg.back.file.service.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,11 +28,20 @@ public class FileController {
     }
 
     @DeleteMapping("")
-    public ApiResponse<Void> createFile(
+    public ApiResponse<Void> deleteFile(
             @RequestBody DeleteFileRequest request
     ) {
         String loginEmail = "ogjg1234@naver.com";
         fileService.deleteFile(loginEmail, request);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
+    @PutMapping("")
+    public ApiResponse<Void> updateFile(
+            @RequestBody UpdateFileRequest request
+    ) {
+        String loginEmail = "ogjg1234@naver.com";
+        fileService.updateFile(loginEmail, request);
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 }

--- a/back/src/main/java/com/ogjg/back/file/controller/FileController.java
+++ b/back/src/main/java/com/ogjg/back/file/controller/FileController.java
@@ -3,6 +3,7 @@ package com.ogjg.back.file.controller;
 import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.response.ApiResponse;
 import com.ogjg.back.file.dto.request.CreateFileRequest;
+import com.ogjg.back.file.dto.request.DeleteFileRequest;
 import com.ogjg.back.file.service.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +23,15 @@ public class FileController {
     ) {
         String loginEmail = "ogjg1234@naver.com";
         fileService.createFile(loginEmail, request);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
+    @DeleteMapping("")
+    public ApiResponse<Void> createFile(
+            @RequestBody DeleteFileRequest request
+    ) {
+        String loginEmail = "ogjg1234@naver.com";
+        fileService.deleteFile(loginEmail, request);
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 }

--- a/back/src/main/java/com/ogjg/back/file/controller/FileController.java
+++ b/back/src/main/java/com/ogjg/back/file/controller/FileController.java
@@ -5,6 +5,7 @@ import com.ogjg.back.common.response.ApiResponse;
 import com.ogjg.back.file.dto.request.CreateFileRequest;
 import com.ogjg.back.file.dto.request.DeleteFileRequest;
 import com.ogjg.back.file.dto.request.UpdateFileRequest;
+import com.ogjg.back.file.dto.request.UpdateFilenameRequest;
 import com.ogjg.back.file.service.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +19,9 @@ public class FileController {
 
     private final FileService fileService;
 
+    /**
+     * 파일 생성
+     */
     @PostMapping("")
     public ApiResponse<Void> createFile(
             @RequestBody CreateFileRequest request
@@ -27,6 +31,9 @@ public class FileController {
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 
+    /**
+     * 파일 삭제
+     */
     @DeleteMapping("")
     public ApiResponse<Void> deleteFile(
             @RequestBody DeleteFileRequest request
@@ -36,12 +43,27 @@ public class FileController {
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 
+    /**
+     * 파일 수정
+     */
     @PutMapping("")
     public ApiResponse<Void> updateFile(
             @RequestBody UpdateFileRequest request
     ) {
         String loginEmail = "ogjg1234@naver.com";
         fileService.updateFile(loginEmail, request);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
+    /**
+     * 파일 이름 수정
+     */
+    @PutMapping("/rename")
+    public ApiResponse<Void> updateFilename(
+            @RequestBody UpdateFilenameRequest request
+    ) {
+        String loginEmail = "ogjg1234@naver.com";
+        fileService.updateFilename(loginEmail, request);
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 }

--- a/back/src/main/java/com/ogjg/back/file/dto/request/CreateFileRequest.java
+++ b/back/src/main/java/com/ogjg/back/file/dto/request/CreateFileRequest.java
@@ -1,0 +1,18 @@
+package com.ogjg.back.file.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class CreateFileRequest {
+    String filePath;
+
+    @Builder
+    public CreateFileRequest(String filePath) {
+        this.filePath = filePath;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/file/dto/request/CreateFileRequest.java
+++ b/back/src/main/java/com/ogjg/back/file/dto/request/CreateFileRequest.java
@@ -9,7 +9,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 public class CreateFileRequest {
-    String filePath;
+    private String filePath;
 
     @Builder
     public CreateFileRequest(String filePath) {

--- a/back/src/main/java/com/ogjg/back/file/dto/request/DeleteFileRequest.java
+++ b/back/src/main/java/com/ogjg/back/file/dto/request/DeleteFileRequest.java
@@ -1,0 +1,18 @@
+package com.ogjg.back.file.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class DeleteFileRequest {
+    String filePath;
+
+    @Builder
+    public DeleteFileRequest(String filePath) {
+        this.filePath = filePath;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/file/dto/request/UpdateFileRequest.java
+++ b/back/src/main/java/com/ogjg/back/file/dto/request/UpdateFileRequest.java
@@ -8,11 +8,14 @@ import static lombok.AccessLevel.PROTECTED;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class DeleteFileRequest {
-    String filePath;
+public class UpdateFileRequest {
+    private String filePath;
+    private String content;
 
     @Builder
-    public DeleteFileRequest(String filePath) {
+    public UpdateFileRequest(String filePath, String content) {
         this.filePath = filePath;
+        this.content = content;
     }
+
 }

--- a/back/src/main/java/com/ogjg/back/file/dto/request/UpdateFileRequest.java
+++ b/back/src/main/java/com/ogjg/back/file/dto/request/UpdateFileRequest.java
@@ -9,7 +9,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 public class DeleteFileRequest {
-    private String filePath;
+    String filePath;
 
     @Builder
     public DeleteFileRequest(String filePath) {

--- a/back/src/main/java/com/ogjg/back/file/dto/request/UpdateFilenameRequest.java
+++ b/back/src/main/java/com/ogjg/back/file/dto/request/UpdateFilenameRequest.java
@@ -1,0 +1,20 @@
+package com.ogjg.back.file.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class UpdateFilenameRequest {
+    private String filePath;
+    private String newFilename;
+
+    @Builder
+    public UpdateFilenameRequest(String filePath, String newFilename) {
+        this.filePath = filePath;
+        this.newFilename = newFilename;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/file/exception/FileAlreadyExists.java
+++ b/back/src/main/java/com/ogjg/back/file/exception/FileAlreadyExists.java
@@ -1,0 +1,19 @@
+package com.ogjg.back.file.exception;
+
+import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorData;
+
+public class FileAlreadyExists extends CustomException {
+    public FileAlreadyExists() {
+        super(ErrorCode.S3_FILE_ALREADY_EXISTS);
+    }
+
+    public FileAlreadyExists(String message) {
+        super(ErrorCode.S3_FILE_ALREADY_EXISTS, message);
+    }
+
+    public FileAlreadyExists(ErrorData errorData) {
+        super(ErrorCode.S3_FILE_ALREADY_EXISTS, errorData);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/file/exception/NotFoundFile.java
+++ b/back/src/main/java/com/ogjg/back/file/exception/NotFoundFile.java
@@ -1,0 +1,19 @@
+package com.ogjg.back.file.exception;
+
+import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorData;
+
+public class NotFoundFile extends CustomException {
+    public NotFoundFile() {
+        super(ErrorCode.S3_NOT_FOUND_FILE);
+    }
+
+    public NotFoundFile(String message) {
+        super(ErrorCode.S3_NOT_FOUND_FILE, message);
+    }
+
+    public NotFoundFile(ErrorData errorData) {
+        super(ErrorCode.S3_NOT_FOUND_FILE, errorData);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/file/service/FileService.java
+++ b/back/src/main/java/com/ogjg/back/file/service/FileService.java
@@ -4,6 +4,7 @@ import com.ogjg.back.container.exception.NotFoundContainer;
 import com.ogjg.back.container.repository.ContainerRepository;
 import com.ogjg.back.file.dto.request.CreateFileRequest;
 import com.ogjg.back.file.dto.request.DeleteFileRequest;
+import com.ogjg.back.file.dto.request.UpdateFileRequest;
 import com.ogjg.back.s3.service.S3FileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,17 +21,29 @@ public class FileService {
     @Transactional
     public void createFile(String loginEmail, CreateFileRequest request) {
         String filePath = request.getFilePath();
-        containerRepository.findByNameAndEmail(extractContainerName(filePath), loginEmail)
-                .orElseThrow(NotFoundContainer::new);
+        if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
 
         s3FileService.createFile(loginEmail, filePath);
     }
 
+    @Transactional
     public void deleteFile(String loginEmail, DeleteFileRequest request) {
         String filePath = request.getFilePath();
-        containerRepository.findByNameAndEmail(extractContainerName(filePath), loginEmail)
-                .orElseThrow(NotFoundContainer::new);
+        if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
 
         s3FileService.deleteFile(loginEmail, filePath);
+    }
+
+    @Transactional
+    public void updateFile(String loginEmail, UpdateFileRequest request) {
+        String filePath = request.getFilePath();
+        if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
+
+        s3FileService.updateFile(loginEmail, filePath, request.getContent());
+    }
+
+    private boolean isContainerExist(String loginEmail, String containerName) {
+        return containerRepository.findByNameAndEmail(containerName, loginEmail)
+                .isPresent();
     }
 }

--- a/back/src/main/java/com/ogjg/back/file/service/FileService.java
+++ b/back/src/main/java/com/ogjg/back/file/service/FileService.java
@@ -1,0 +1,27 @@
+package com.ogjg.back.file.service;
+
+import com.ogjg.back.container.exception.NotFoundContainer;
+import com.ogjg.back.container.repository.ContainerRepository;
+import com.ogjg.back.file.dto.request.CreateFileRequest;
+import com.ogjg.back.s3.service.S3FileService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.ogjg.back.common.util.S3PathUtil.extractContainerName;
+
+@Service
+@RequiredArgsConstructor
+public class FileService {
+    private final ContainerRepository containerRepository;
+    private final S3FileService s3FileService;
+
+    @Transactional
+    public void createFile(String loginEmail, CreateFileRequest request) {
+        String filePath = request.getFilePath();
+        containerRepository.findByNameAndEmail(extractContainerName(filePath), loginEmail)
+                .orElseThrow(NotFoundContainer::new);
+
+        s3FileService.createFile(loginEmail, filePath);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/file/service/FileService.java
+++ b/back/src/main/java/com/ogjg/back/file/service/FileService.java
@@ -6,14 +6,15 @@ import com.ogjg.back.file.dto.request.CreateFileRequest;
 import com.ogjg.back.file.dto.request.DeleteFileRequest;
 import com.ogjg.back.file.dto.request.UpdateFileRequest;
 import com.ogjg.back.file.dto.request.UpdateFilenameRequest;
+import com.ogjg.back.file.exception.FileAlreadyExists;
+import com.ogjg.back.file.exception.NotFoundFile;
 import com.ogjg.back.s3.service.S3FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.ogjg.back.common.util.S3PathUtil.createNewFilePath;
-import static com.ogjg.back.common.util.S3PathUtil.extractContainerName;
+import static com.ogjg.back.common.util.S3PathUtil.*;
 
 @Slf4j
 @Service
@@ -27,7 +28,10 @@ public class FileService {
     @Transactional
     public void createFile(String loginEmail, CreateFileRequest request) {
         String filePath = request.getFilePath();
+        String s3Path = createS3PathWithFilePath(loginEmail, filePath);
+
         if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
+        if (s3FileService.isFileAlreadyExist(s3Path)) throw new FileAlreadyExists();
 
         s3FileService.createFile(loginEmail, filePath);
     }
@@ -35,7 +39,10 @@ public class FileService {
     @Transactional
     public void deleteFile(String loginEmail, DeleteFileRequest request) {
         String filePath = request.getFilePath();
+        String s3Path = createS3PathWithFilePath(loginEmail, filePath);
+
         if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
+        if (!s3FileService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
 
         s3FileService.deleteFile(loginEmail, filePath);
     }
@@ -43,7 +50,10 @@ public class FileService {
     @Transactional
     public void updateFile(String loginEmail, UpdateFileRequest request) {
         String filePath = request.getFilePath();
+        String s3Path = createS3PathWithFilePath(loginEmail, filePath);
+
         if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
+        if (!s3FileService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
 
         s3FileService.updateFile(loginEmail, filePath, request.getContent());
     }
@@ -52,10 +62,12 @@ public class FileService {
     public void updateFilename(String loginEmail, UpdateFilenameRequest request) {
         String filePath = request.getFilePath();
         String newFilename = request.getNewFilename();
+        String s3Path = createS3PathWithFilePath(loginEmail, filePath);
 
         String newFilePath = createNewFilePath(filePath, newFilename);
         log.info("newPath={}", newFilePath);
         if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
+        if (!s3FileService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
 
         s3FileService.updateFilename(loginEmail, filePath, newFilePath);
     }

--- a/back/src/main/java/com/ogjg/back/file/service/FileService.java
+++ b/back/src/main/java/com/ogjg/back/file/service/FileService.java
@@ -5,18 +5,24 @@ import com.ogjg.back.container.repository.ContainerRepository;
 import com.ogjg.back.file.dto.request.CreateFileRequest;
 import com.ogjg.back.file.dto.request.DeleteFileRequest;
 import com.ogjg.back.file.dto.request.UpdateFileRequest;
+import com.ogjg.back.file.dto.request.UpdateFilenameRequest;
 import com.ogjg.back.s3.service.S3FileService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.ogjg.back.common.util.S3PathUtil.createNewFilePath;
 import static com.ogjg.back.common.util.S3PathUtil.extractContainerName;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FileService {
     private final ContainerRepository containerRepository;
     private final S3FileService s3FileService;
+
+    // todo : 모든 로직에 해당 파일이 존재하는지 여부 확인 필요하다.
 
     @Transactional
     public void createFile(String loginEmail, CreateFileRequest request) {
@@ -40,6 +46,18 @@ public class FileService {
         if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
 
         s3FileService.updateFile(loginEmail, filePath, request.getContent());
+    }
+
+    @Transactional
+    public void updateFilename(String loginEmail, UpdateFilenameRequest request) {
+        String filePath = request.getFilePath();
+        String newFilename = request.getNewFilename();
+
+        String newFilePath = createNewFilePath(filePath, newFilename);
+        log.info("newPath={}", newFilePath);
+        if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
+
+        s3FileService.updateFilename(loginEmail, filePath, newFilePath);
     }
 
     private boolean isContainerExist(String loginEmail, String containerName) {

--- a/back/src/main/java/com/ogjg/back/file/service/FileService.java
+++ b/back/src/main/java/com/ogjg/back/file/service/FileService.java
@@ -3,6 +3,7 @@ package com.ogjg.back.file.service;
 import com.ogjg.back.container.exception.NotFoundContainer;
 import com.ogjg.back.container.repository.ContainerRepository;
 import com.ogjg.back.file.dto.request.CreateFileRequest;
+import com.ogjg.back.file.dto.request.DeleteFileRequest;
 import com.ogjg.back.s3.service.S3FileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,5 +24,13 @@ public class FileService {
                 .orElseThrow(NotFoundContainer::new);
 
         s3FileService.createFile(loginEmail, filePath);
+    }
+
+    public void deleteFile(String loginEmail, DeleteFileRequest request) {
+        String filePath = request.getFilePath();
+        containerRepository.findByNameAndEmail(extractContainerName(filePath), loginEmail)
+                .orElseThrow(NotFoundContainer::new);
+
+        s3FileService.deleteFile(loginEmail, filePath);
     }
 }

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
@@ -1,0 +1,46 @@
+package com.ogjg.back.s3.repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.net.URLConnection;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class S3FileRepository {
+
+    @Value("${cloud.aws.credentials.bucket-name}")
+    private String bucketName;
+
+    private final S3Client s3Client;
+
+    public void putFilePath(String filePath) {
+        try {
+            // 파일 확장자를 통해 MIME 타입을 가져옴
+            String mimeType = URLConnection.guessContentTypeFromName(filePath);
+            if (mimeType == null) {
+                mimeType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
+            }
+
+            // S3에 파일 업로드
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(filePath)
+                    .contentType(mimeType)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromString(filePath));
+
+        } catch (Exception e) {
+            log.error("error message={}", e.getMessage());
+        }
+    }
+
+}

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Repository;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.net.URLConnection;
@@ -43,4 +44,16 @@ public class S3FileRepository {
         }
     }
 
+    public void deleteFile(String filePath) {
+        try {
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(filePath)
+                    .build();
+
+            s3Client.deleteObject(request);
+        } catch (Exception e) {
+            log.error("error message={}", e.getMessage());
+        }
+    }
 }

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
@@ -56,4 +56,17 @@ public class S3FileRepository {
             log.error("error message={}", e.getMessage());
         }
     }
+
+    public void putFile(String filePath, String content) {
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(filePath)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromString(content));
+        } catch (Exception e) {
+            log.error("error message={}", e.getMessage());
+        }
+    }
 }

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Repository;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
@@ -17,6 +18,7 @@ import java.net.URLConnection;
 @RequiredArgsConstructor
 public class S3FileRepository {
 
+    public static final String EMPTY = "";
     @Value("${cloud.aws.credentials.bucket-name}")
     private String bucketName;
 
@@ -37,7 +39,7 @@ public class S3FileRepository {
                     .contentType(mimeType)
                     .build();
 
-            s3Client.putObject(putObjectRequest, RequestBody.fromString(filePath));
+            s3Client.putObject(putObjectRequest, RequestBody.fromString(EMPTY));
 
         } catch (Exception e) {
             log.error("error message={}", e.getMessage());
@@ -65,6 +67,27 @@ public class S3FileRepository {
                     .build();
 
             s3Client.putObject(putObjectRequest, RequestBody.fromString(content));
+        } catch (Exception e) {
+            log.error("error message={}", e.getMessage());
+        }
+    }
+
+    public void rename(String filePath, String newFilePath) {
+        log.info("nowFilePath={}", filePath);
+        log.info("newFilePath={}", newFilePath);
+        try {
+            CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder()
+                    .sourceBucket(bucketName)
+                    .sourceKey(filePath)
+                    .destinationBucket(bucketName)
+                    .destinationKey(newFilePath)
+                    .build();
+
+            s3Client.copyObject(copyObjectRequest);
+
+            // 기존 파일 삭
+            deleteFile(filePath);
+
         } catch (Exception e) {
             log.error("error message={}", e.getMessage());
         }

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
@@ -7,9 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Repository;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
-import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.*;
 
 import java.net.URLConnection;
 
@@ -24,10 +22,10 @@ public class S3FileRepository {
 
     private final S3Client s3Client;
 
-    public void putFilePath(String filePath) {
+    public void putFilePath(String s3Path) {
         try {
             // 파일 확장자를 통해 MIME 타입을 가져옴
-            String mimeType = URLConnection.guessContentTypeFromName(filePath);
+            String mimeType = URLConnection.guessContentTypeFromName(s3Path);
             if (mimeType == null) {
                 mimeType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
             }
@@ -35,7 +33,7 @@ public class S3FileRepository {
             // S3에 파일 업로드
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucketName)
-                    .key(filePath)
+                    .key(s3Path)
                     .contentType(mimeType)
                     .build();
 
@@ -46,11 +44,11 @@ public class S3FileRepository {
         }
     }
 
-    public void deleteFile(String filePath) {
+    public void deleteFile(String s3Path) {
         try {
             DeleteObjectRequest request = DeleteObjectRequest.builder()
                     .bucket(bucketName)
-                    .key(filePath)
+                    .key(s3Path)
                     .build();
 
             s3Client.deleteObject(request);
@@ -59,11 +57,11 @@ public class S3FileRepository {
         }
     }
 
-    public void putFile(String filePath, String content) {
+    public void putFile(String s3Path, String content) {
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucketName)
-                    .key(filePath)
+                    .key(s3Path)
                     .build();
 
             s3Client.putObject(putObjectRequest, RequestBody.fromString(content));
@@ -72,13 +70,13 @@ public class S3FileRepository {
         }
     }
 
-    public void rename(String filePath, String newFilePath) {
-        log.info("nowFilePath={}", filePath);
+    public void rename(String s3Path, String newFilePath) {
+        log.info("nowFilePath={}", s3Path);
         log.info("newFilePath={}", newFilePath);
         try {
             CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder()
                     .sourceBucket(bucketName)
-                    .sourceKey(filePath)
+                    .sourceKey(s3Path)
                     .destinationBucket(bucketName)
                     .destinationKey(newFilePath)
                     .build();
@@ -86,10 +84,24 @@ public class S3FileRepository {
             s3Client.copyObject(copyObjectRequest);
 
             // 기존 파일 삭
-            deleteFile(filePath);
+            deleteFile(s3Path);
 
         } catch (Exception e) {
             log.error("error message={}", e.getMessage());
+        }
+    }
+
+    public boolean isFileExist(String s3Path) {
+        try {
+            HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Path)
+                    .build();
+
+            s3Client.headObject(headObjectRequest);
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
         }
     }
 }

--- a/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
@@ -16,4 +16,10 @@ public class S3FileService {
                 createS3PathWithFilePath(email, filePath)
         );
     }
+
+    public void deleteFile(String email, String filePath) {
+        s3FileRepository.deleteFile(
+                createS3PathWithFilePath(email, filePath)
+        );
+    }
 }

--- a/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
@@ -33,4 +33,12 @@ public class S3FileService {
                 content
         );
     }
+
+    @Transactional
+    public void updateFilename(String email, String filePath, String newFilePath) {
+        s3FileRepository.rename(
+                createS3PathWithFilePath(email, filePath),
+                createS3PathWithFilePath(email, newFilePath)
+        );
+    }
 }

--- a/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
@@ -3,6 +3,7 @@ package com.ogjg.back.s3.service;
 import com.ogjg.back.s3.repository.S3FileRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import static com.ogjg.back.common.util.S3PathUtil.createS3PathWithFilePath;
 
@@ -11,15 +12,25 @@ import static com.ogjg.back.common.util.S3PathUtil.createS3PathWithFilePath;
 public class S3FileService {
 
     private final S3FileRepository s3FileRepository;
+
+    @Transactional
     public void createFile(String email, String filePath) {
         s3FileRepository.putFilePath(
                 createS3PathWithFilePath(email, filePath)
         );
     }
 
+    @Transactional
     public void deleteFile(String email, String filePath) {
         s3FileRepository.deleteFile(
                 createS3PathWithFilePath(email, filePath)
+        );
+    }
+    @Transactional
+    public void updateFile(String email, String filePath, String content) {
+        s3FileRepository.putFile(
+                createS3PathWithFilePath(email, filePath),
+                content
         );
     }
 }

--- a/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
@@ -1,0 +1,19 @@
+package com.ogjg.back.s3.service;
+
+import com.ogjg.back.s3.repository.S3FileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.ogjg.back.common.util.S3PathUtil.createS3PathWithFilePath;
+
+@Service
+@RequiredArgsConstructor
+public class S3FileService {
+
+    private final S3FileRepository s3FileRepository;
+    public void createFile(String email, String filePath) {
+        s3FileRepository.putFilePath(
+                createS3PathWithFilePath(email, filePath)
+        );
+    }
+}

--- a/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
@@ -41,4 +41,9 @@ public class S3FileService {
                 createS3PathWithFilePath(email, newFilePath)
         );
     }
+
+    @Transactional(readOnly = true)
+    public boolean isFileAlreadyExist(String filePath) {
+        return s3FileRepository.isFileExist(filePath);
+    }
 }

--- a/back/src/test/java/com/ogjg/back/common/ControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/common/ControllerTest.java
@@ -3,6 +3,8 @@ package com.ogjg.back.common;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ogjg.back.container.controller.ContainerController;
 import com.ogjg.back.container.service.ContainerService;
+import com.ogjg.back.file.controller.FileController;
+import com.ogjg.back.file.service.FileService;
 import com.ogjg.back.s3.service.S3ProfileImageService;
 import com.ogjg.back.user.controller.UserController;
 import com.ogjg.back.user.service.EmailAuthService;
@@ -24,7 +26,8 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 @AutoConfigureRestDocs
 @WebMvcTest({
         UserController.class,
-        ContainerController.class
+        ContainerController.class,
+        FileController.class
 })
 public class ControllerTest {
 
@@ -56,4 +59,7 @@ public class ControllerTest {
 
     @MockBean
     protected S3ProfileImageService s3ProfileImageService;
+
+    @MockBean
+    protected FileService fileService;
 }

--- a/back/src/test/java/com/ogjg/back/container/controller/FileControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/container/controller/FileControllerTest.java
@@ -2,6 +2,7 @@ package com.ogjg.back.container.controller;
 
 import com.ogjg.back.common.ControllerTest;
 import com.ogjg.back.file.dto.request.CreateFileRequest;
+import com.ogjg.back.file.dto.request.DeleteFileRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -10,6 +11,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -32,7 +34,7 @@ public class FileControllerTest extends ControllerTest {
                 post("/api/files")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
-//                        .accept(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
         );
 
         //then
@@ -49,4 +51,37 @@ public class FileControllerTest extends ControllerTest {
                 )
         )).andExpect(status().isOk());
      }
+
+    @DisplayName("파일 삭제")
+    @Test
+    public void deleteFile() throws Exception {
+        //given
+        DeleteFileRequest request = DeleteFileRequest.builder()
+                .filePath("/my-container1/hello")
+                .build();
+
+        doNothing().when(fileService).deleteFile(any(String.class), any(DeleteFileRequest.class));
+
+        //when
+        ResultActions result = this.mockMvc.perform(
+                delete("/api/files")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        result.andDo(document("file/delete",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                        fieldWithPath("filePath").description("삭제할 파일 전체 경로")
+                ),
+                responseFields(
+                        fieldWithPath("status.code").description("응답 코드"),
+                        fieldWithPath("status.message").description("응답 메시지"),
+                        fieldWithPath("data").description("응답 데이터")
+                )
+        )).andExpect(status().isOk());
+    }
 }

--- a/back/src/test/java/com/ogjg/back/container/controller/FileControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/container/controller/FileControllerTest.java
@@ -1,0 +1,52 @@
+package com.ogjg.back.container.controller;
+
+import com.ogjg.back.common.ControllerTest;
+import com.ogjg.back.file.dto.request.CreateFileRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.doNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class FileControllerTest extends ControllerTest {
+
+    @DisplayName("파일 생성")
+    @Test
+    public void createFile() throws Exception {
+        //given
+        CreateFileRequest request = CreateFileRequest.builder()
+                .filePath("/my-container1/hello.txt")
+                .build();
+
+        doNothing().when(fileService).createFile(any(String.class), any(CreateFileRequest.class));
+
+        //when
+        ResultActions result = this.mockMvc.perform(
+                post("/api/files")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+//                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        result.andDo(document("file/create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                        fieldWithPath("filePath").description("생성할 파일 전체 경로")
+                ),
+                responseFields(
+                        fieldWithPath("status.code").description("응답 코드"),
+                        fieldWithPath("status.message").description("응답 메시지"),
+                        fieldWithPath("data").description("응답 데이터")
+                )
+        )).andExpect(status().isOk());
+     }
+}

--- a/back/src/test/java/com/ogjg/back/file/controller/FileControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/file/controller/FileControllerTest.java
@@ -1,8 +1,9 @@
-package com.ogjg.back.container.controller;
+package com.ogjg.back.file.controller;
 
 import com.ogjg.back.common.ControllerTest;
 import com.ogjg.back.file.dto.request.CreateFileRequest;
 import com.ogjg.back.file.dto.request.DeleteFileRequest;
+import com.ogjg.back.file.dto.request.UpdateFileRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -76,6 +77,42 @@ public class FileControllerTest extends ControllerTest {
                 preprocessResponse(prettyPrint()),
                 requestFields(
                         fieldWithPath("filePath").description("삭제할 파일 전체 경로")
+                ),
+                responseFields(
+                        fieldWithPath("status.code").description("응답 코드"),
+                        fieldWithPath("status.message").description("응답 메시지"),
+                        fieldWithPath("data").description("응답 데이터")
+                )
+        )).andExpect(status().isOk());
+    }
+
+    @DisplayName("파일 수정")
+    @Test
+    public void updateFile() throws Exception {
+        //given
+        UpdateFileRequest request = UpdateFileRequest.builder()
+                .content("content...\n I'am a cbum. muscle king.\n" +
+                        "do you know?")
+                .filePath("/my-container1/hello")
+                .build();
+
+        doNothing().when(fileService).updateFile(any(String.class), any(UpdateFileRequest.class));
+
+        //when
+        ResultActions result = this.mockMvc.perform(
+                delete("/api/files")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        result.andDo(document("file/update",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                        fieldWithPath("filePath").description("수정할 파일 전체 경로"),
+                        fieldWithPath("content").description("수정한 파일 전체 내용")
                 ),
                 responseFields(
                         fieldWithPath("status.code").description("응답 코드"),


### PR DESCRIPTION
### Feat : OW-66 파일 생성 API 및 테스트 추가 

- [x] 파일 생성 기능 구현
  - 경로 인코딩 문제로 requestBody 사용
  - S3로직을 Service, Repository 별로 분리
- [x] 테스트 및 문서화 추가
  - ControllerTest 추가
  - adoc 정리 및 추가된 내용 갱신

### Feat : OW-66 파일 삭제 API 및 테스트 추가

- [x] 파일 삭제 기능 구현
- [x] Controller 테스트 추가
- [x] adoc 갱신 및 정리
  - 삭제 기능 추가
  - include 사이 줄바꿈 추가해서 포매팅이 깨지지 않게 수정

### Feat : OW-66 누락된 private 접근제어자 추가

### Feat : OW-66 파일 수정 API 및 테스트 추가
- [x] 파일 삭제 기능 구현
  - Controller 테스트 추가
  - adoc 갱신 및 정리
- [x] 코드 정리, 수정
  - FileController 메서드명 수정
  - S3File/FileService에 누락된 @transactional 추가
  - file.controller 패키지 생성, FileControllerTest 패키지 이동
  - FileService에서 컨테이너가 존재하는지 확인하는 로직 메서드 추출

### Feat : OW-66 파일 이름 수정 API 및 테스트 추가

- [x] 파일 이름 수정 기능 구현 
  - 새로운 키에 파일을 복사하고 이전 키와 데이터를 삭제하는 방식으로 구현
  - Controller 테스트 추가
  - rest docs 테스트 스크립트 일부 정리
  - adoc 갱신 및 정리
- [x] 파일 생성 기능 기본 데이터 값 수정
  - 파일 생성 시 내용이 없는 빈 파일로 생성하도록 수정