### PR TITLE
Feat : OW-65 디렉토리 관리 API 구현

### DIFF
--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -108,3 +108,13 @@ include::{snippets}/file/rename/http-request.adoc[]
 include::{snippets}/file/rename/request-fields.adoc[]
 
 include::{snippets}/file/rename/http-response.adoc[]
+
+== 디렉토리 API
+
+=== 디렉토리 생성
+해당 경로의 파일을 생성합니다.
+
+include::{snippets}/directory/create/http-request.adoc[]
+include::{snippets}/directory/create/request-fields.adoc[]
+
+include::{snippets}/directory/create/http-response.adoc[]

--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -118,3 +118,11 @@ include::{snippets}/directory/create/http-request.adoc[]
 include::{snippets}/directory/create/request-fields.adoc[]
 
 include::{snippets}/directory/create/http-response.adoc[]
+
+=== 디렉토리 삭제
+해당 경로의 파일을 생성합니다.
+
+include::{snippets}/directory/delete/http-request.adoc[]
+include::{snippets}/directory/delete/request-fields.adoc[]
+
+include::{snippets}/directory/delete/http-response.adoc[]

--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -126,3 +126,11 @@ include::{snippets}/directory/delete/http-request.adoc[]
 include::{snippets}/directory/delete/request-fields.adoc[]
 
 include::{snippets}/directory/delete/http-response.adoc[]
+
+=== 디렉토리 이름 수정
+해당 경로의 파일을 생성합니다.
+
+include::{snippets}/directory/rename/http-request.adoc[]
+include::{snippets}/directory/rename/request-fields.adoc[]
+
+include::{snippets}/directory/rename/http-response.adoc[]

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "400", "현재 비밀번호 불일치"),
     S3_NOT_FOUND_FILE(HttpStatus.NOT_FOUND, "400", "S3에 존재하지 않는 파일입니다."),
     S3_FILE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "400", "S3에 이미 존재하는 파일입니다."),
+    S3_DIRECTORY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "400", "S3에 이미 존재하는 디렉토리입니다."),
     S3_FAIL_TO_UPLOAD_CONTAINER(HttpStatus.BAD_REQUEST, "400", "S3에 컨테이너 초기파일 업로드를 실패했습니다."),
     S3_FAIL_TO_UPLOAD_IMAGE(HttpStatus.BAD_REQUEST, "400", "S3에 프로필 이미지 업로드를 실패했습니다.");
 

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
     DUPLICATED_CONTAINER_NAME(HttpStatus.BAD_REQUEST, "400", "이미 존재하는 컨테이너 이름입니다"),
     INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "400", "현재 비밀번호 불일치"),
     S3_NOT_FOUND_FILE(HttpStatus.NOT_FOUND, "400", "S3에 존재하지 않는 파일입니다."),
+    S3_NOT_FOUND_DIRECTORY(HttpStatus.NOT_FOUND, "400", "S3에 존재하지 않는 디렉토리입니다."),
     S3_FILE_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "400", "S3에 이미 존재하는 파일입니다."),
     S3_DIRECTORY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "400", "S3에 이미 존재하는 디렉토리입니다."),
     S3_FAIL_TO_UPLOAD_CONTAINER(HttpStatus.BAD_REQUEST, "400", "S3에 컨테이너 초기파일 업로드를 실패했습니다."),

--- a/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
+++ b/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
@@ -16,7 +16,7 @@ public class S3PathUtil {
 
     }
 
-    public static String createS3PathWithFilePath(String loginEmail, String filePath) {
+    public static String givenPathToS3Path(String loginEmail, String filePath) {
         loginEmail = loginEmail
                 .replace('.', S3_EMAIL_DELIMETER)
                 .replace('@', S3_EMAIL_DELIMETER);

--- a/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
+++ b/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
@@ -1,5 +1,7 @@
 package com.ogjg.back.common.util;
 
+import software.amazon.awssdk.services.s3.model.S3Object;
+
 public class S3PathUtil {
 
     public static final String DELIMITER = "/";
@@ -43,5 +45,16 @@ public class S3PathUtil {
     public static String createNewFilePath(String originPath, String newFilename) {
         int lastDelimiterIndex = originPath.lastIndexOf(DELIMITER);
         return originPath.substring(0, lastDelimiterIndex) + DELIMITER + newFilename;
+    }
+
+    public static String createNewDirectoryPath(String originPath, String newFilename) {
+        String temp = originPath.substring(0, originPath.length() - 1);
+        int secondLastDelimiterIndex = temp.lastIndexOf(DELIMITER);
+
+        return originPath.substring(0, secondLastDelimiterIndex) + DELIMITER + newFilename + DELIMITER;
+    }
+
+    public static String createNewKey(String originPrefix, String newS3Path, S3Object s3Object) {
+        return newS3Path + s3Object.key().substring(originPrefix.length());
     }
 }

--- a/back/src/main/java/com/ogjg/back/directory/controller/DirectoryController.java
+++ b/back/src/main/java/com/ogjg/back/directory/controller/DirectoryController.java
@@ -4,6 +4,7 @@ import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.response.ApiResponse;
 import com.ogjg.back.directory.dto.request.CreateDirectoryRequest;
 import com.ogjg.back.directory.dto.request.DeleteDirectoryRequest;
+import com.ogjg.back.directory.dto.request.UpdateDirectoryNameRequest;
 import com.ogjg.back.directory.service.DirectoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,4 +42,15 @@ public class DirectoryController {
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 
+    /**
+     * 디렉토리 이름 수정
+     */
+    @PutMapping("/rename")
+    public ApiResponse<Void> updateFilename(
+            @RequestBody UpdateDirectoryNameRequest request
+    ) {
+        String loginEmail = "ogjg1234@naver.com";
+        directoryService.updateDirectoryName(loginEmail, request);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
 }

--- a/back/src/main/java/com/ogjg/back/directory/controller/DirectoryController.java
+++ b/back/src/main/java/com/ogjg/back/directory/controller/DirectoryController.java
@@ -1,0 +1,33 @@
+package com.ogjg.back.directory.controller;
+
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.response.ApiResponse;
+import com.ogjg.back.directory.dto.request.CreateDirectoryRequest;
+import com.ogjg.back.directory.service.DirectoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/directories")
+public class DirectoryController {
+
+    private final DirectoryService directoryService;
+
+    /**
+     * 디렉토리 생성
+     */
+    @PostMapping("")
+    public ApiResponse<Void> creatDirectory(
+            @RequestBody CreateDirectoryRequest request
+    ) {
+        String loginEmail = "ogjg1234@naver.com";
+        directoryService.createDirectory(loginEmail, request);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/directory/controller/DirectoryController.java
+++ b/back/src/main/java/com/ogjg/back/directory/controller/DirectoryController.java
@@ -3,13 +3,11 @@ package com.ogjg.back.directory.controller;
 import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.response.ApiResponse;
 import com.ogjg.back.directory.dto.request.CreateDirectoryRequest;
+import com.ogjg.back.directory.dto.request.DeleteDirectoryRequest;
 import com.ogjg.back.directory.service.DirectoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -30,4 +28,17 @@ public class DirectoryController {
         directoryService.createDirectory(loginEmail, request);
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
+
+    /**
+     * 디렉토리 삭제
+     */
+    @DeleteMapping("")
+    public ApiResponse<Void> deleteDirectory(
+            @RequestBody DeleteDirectoryRequest request
+    ) {
+        String loginEmail = "ogjg1234@naver.com";
+        directoryService.deleteDirectory(loginEmail, request);
+        return new ApiResponse<>(ErrorCode.SUCCESS);
+    }
+
 }

--- a/back/src/main/java/com/ogjg/back/directory/dto/request/CreateDirectoryRequest.java
+++ b/back/src/main/java/com/ogjg/back/directory/dto/request/CreateDirectoryRequest.java
@@ -1,0 +1,18 @@
+package com.ogjg.back.directory.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class CreateDirectoryRequest {
+    private String directoryPath;
+
+    @Builder
+    public CreateDirectoryRequest(String directoryPath) {
+        this.directoryPath = directoryPath;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/directory/dto/request/DeleteDirectoryRequest.java
+++ b/back/src/main/java/com/ogjg/back/directory/dto/request/DeleteDirectoryRequest.java
@@ -1,0 +1,18 @@
+package com.ogjg.back.directory.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class DeleteDirectoryRequest {
+    private String directoryPath;
+
+    @Builder
+    public DeleteDirectoryRequest(String directoryPath) {
+        this.directoryPath = directoryPath;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/directory/dto/request/UpdateDirectoryNameRequest.java
+++ b/back/src/main/java/com/ogjg/back/directory/dto/request/UpdateDirectoryNameRequest.java
@@ -1,0 +1,20 @@
+package com.ogjg.back.directory.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class UpdateDirectoryNameRequest {
+    private String directoryPath;
+    private String newDirectoryName;
+
+    @Builder
+    public UpdateDirectoryNameRequest(String directoryPath, String newDirectoryName) {
+        this.directoryPath = directoryPath;
+        this.newDirectoryName = newDirectoryName;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/directory/exception/DirectoryAlreadyExists.java
+++ b/back/src/main/java/com/ogjg/back/directory/exception/DirectoryAlreadyExists.java
@@ -1,0 +1,19 @@
+package com.ogjg.back.directory.exception;
+
+import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorData;
+
+public class DirectoryAlreadyExists extends CustomException {
+    public DirectoryAlreadyExists() {
+        super(ErrorCode.S3_DIRECTORY_ALREADY_EXISTS);
+    }
+
+    public DirectoryAlreadyExists(String message) {
+        super(ErrorCode.S3_DIRECTORY_ALREADY_EXISTS, message);
+    }
+
+    public DirectoryAlreadyExists(ErrorData errorData) {
+        super(ErrorCode.S3_DIRECTORY_ALREADY_EXISTS, errorData);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/directory/exception/NotFoundDirectory.java
+++ b/back/src/main/java/com/ogjg/back/directory/exception/NotFoundDirectory.java
@@ -1,0 +1,19 @@
+package com.ogjg.back.directory.exception;
+
+import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorData;
+
+public class NotFoundDirectory extends CustomException {
+    public NotFoundDirectory() {
+        super(ErrorCode.S3_NOT_FOUND_DIRECTORY);
+    }
+
+    public NotFoundDirectory(String message) {
+        super(ErrorCode.S3_NOT_FOUND_DIRECTORY, message);
+    }
+
+    public NotFoundDirectory(ErrorData errorData) {
+        super(ErrorCode.S3_NOT_FOUND_DIRECTORY, errorData);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/directory/service/DirectoryService.java
+++ b/back/src/main/java/com/ogjg/back/directory/service/DirectoryService.java
@@ -3,7 +3,9 @@ package com.ogjg.back.directory.service;
 import com.ogjg.back.container.exception.NotFoundContainer;
 import com.ogjg.back.container.repository.ContainerRepository;
 import com.ogjg.back.directory.dto.request.CreateDirectoryRequest;
+import com.ogjg.back.directory.dto.request.DeleteDirectoryRequest;
 import com.ogjg.back.directory.exception.DirectoryAlreadyExists;
+import com.ogjg.back.directory.exception.NotFoundDirectory;
 import com.ogjg.back.s3.service.S3DirectoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +32,19 @@ public class DirectoryService {
         if (s3DirectoryService.isDirectoryAlreadyExist(s3Path)) throw new DirectoryAlreadyExists();
 
         s3DirectoryService.createDirectory(loginEmail, directoryPath);
+    }
+
+    @Transactional
+    public void deleteDirectory(String loginEmail, DeleteDirectoryRequest request) {
+        String directoryPath = request.getDirectoryPath();
+        String s3Path = givenPathToS3Path(loginEmail, directoryPath);
+
+        log.info("directory s3Path={}", s3Path);
+
+        if (!isContainerExist(loginEmail, extractContainerName(directoryPath))) throw new NotFoundContainer();
+        if (!s3DirectoryService.isDirectoryAlreadyExist(s3Path)) throw new NotFoundDirectory();
+
+        s3DirectoryService.deleteDirectory(loginEmail, directoryPath);
     }
 
     private boolean isContainerExist(String loginEmail, String containerName) {

--- a/back/src/main/java/com/ogjg/back/directory/service/DirectoryService.java
+++ b/back/src/main/java/com/ogjg/back/directory/service/DirectoryService.java
@@ -1,0 +1,39 @@
+package com.ogjg.back.directory.service;
+
+import com.ogjg.back.container.exception.NotFoundContainer;
+import com.ogjg.back.container.repository.ContainerRepository;
+import com.ogjg.back.directory.dto.request.CreateDirectoryRequest;
+import com.ogjg.back.directory.exception.DirectoryAlreadyExists;
+import com.ogjg.back.s3.service.S3DirectoryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.ogjg.back.common.util.S3PathUtil.extractContainerName;
+import static com.ogjg.back.common.util.S3PathUtil.givenPathToS3Path;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DirectoryService {
+
+    private final ContainerRepository containerRepository;
+    private final S3DirectoryService s3DirectoryService;
+
+    @Transactional
+    public void createDirectory(String loginEmail, CreateDirectoryRequest request) {
+        String directoryPath = request.getDirectoryPath();
+        String s3Path = givenPathToS3Path(loginEmail, directoryPath);
+
+        if (!isContainerExist(loginEmail, extractContainerName(directoryPath))) throw new NotFoundContainer();
+        if (s3DirectoryService.isDirectoryAlreadyExist(s3Path)) throw new DirectoryAlreadyExists();
+
+        s3DirectoryService.createDirectory(loginEmail, directoryPath);
+    }
+
+    private boolean isContainerExist(String loginEmail, String containerName) {
+        return containerRepository.findByNameAndEmail(containerName, loginEmail)
+                .isPresent();
+    }
+}

--- a/back/src/main/java/com/ogjg/back/file/service/FileService.java
+++ b/back/src/main/java/com/ogjg/back/file/service/FileService.java
@@ -28,7 +28,7 @@ public class FileService {
     @Transactional
     public void createFile(String loginEmail, CreateFileRequest request) {
         String filePath = request.getFilePath();
-        String s3Path = createS3PathWithFilePath(loginEmail, filePath);
+        String s3Path = givenPathToS3Path(loginEmail, filePath);
 
         if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
         if (s3FileService.isFileAlreadyExist(s3Path)) throw new FileAlreadyExists();
@@ -39,7 +39,7 @@ public class FileService {
     @Transactional
     public void deleteFile(String loginEmail, DeleteFileRequest request) {
         String filePath = request.getFilePath();
-        String s3Path = createS3PathWithFilePath(loginEmail, filePath);
+        String s3Path = givenPathToS3Path(loginEmail, filePath);
 
         if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
         if (!s3FileService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
@@ -50,7 +50,7 @@ public class FileService {
     @Transactional
     public void updateFile(String loginEmail, UpdateFileRequest request) {
         String filePath = request.getFilePath();
-        String s3Path = createS3PathWithFilePath(loginEmail, filePath);
+        String s3Path = givenPathToS3Path(loginEmail, filePath);
 
         if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
         if (!s3FileService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
@@ -62,7 +62,7 @@ public class FileService {
     public void updateFilename(String loginEmail, UpdateFilenameRequest request) {
         String filePath = request.getFilePath();
         String newFilename = request.getNewFilename();
-        String s3Path = createS3PathWithFilePath(loginEmail, filePath);
+        String s3Path = givenPathToS3Path(loginEmail, filePath);
 
         String newFilePath = createNewFilePath(filePath, newFilename);
         log.info("newPath={}", newFilePath);

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3DirectoryRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3DirectoryRepository.java
@@ -1,0 +1,72 @@
+package com.ogjg.back.s3.repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class S3DirectoryRepository {
+    public static final String EMPTY = "";
+    @Value("${cloud.aws.credentials.bucket-name}")
+    private String bucketName;
+
+    private final S3Client s3Client;
+
+    public void putDirectoryPath(String directoryPath) {
+        try {
+            // S3에 디렉토리 업로드
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(directoryPath)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromString(EMPTY));
+
+        } catch (Exception e) {
+            log.error("error message={}", e.getMessage());
+        }
+    }
+
+    public boolean isDirectoryExist(String s3Path) {
+        try {
+            HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Path)
+                    .build();
+
+            s3Client.headObject(headObjectRequest);
+            return true;
+        } catch (NoSuchKeyException e) {
+            return false;
+        }
+    }
+
+    public void deleteObjectsWithPrefix(String prefix) {
+        try {
+            ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder()
+                    .bucket(bucketName)
+                    .prefix(prefix)
+                    .build();
+
+            s3Client.listObjectsV2(listObjectsV2Request).contents().stream()
+                    .map((content) -> toDeleteObjectRequest(content))
+                    .forEach((request) -> s3Client.deleteObject(request));
+
+        } catch (Exception e) {
+            log.error("error message={}",e.getMessage());
+        }
+    }
+
+    private DeleteObjectRequest toDeleteObjectRequest(S3Object content) {
+        return DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(content.key())
+                .build();
+    }
+}

--- a/back/src/main/java/com/ogjg/back/s3/service/S3DirectoryService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3DirectoryService.java
@@ -20,8 +20,15 @@ public class S3DirectoryService {
         );
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public boolean isDirectoryAlreadyExist(String s3Path) {
         return s3DirectoryRepository.isDirectoryExist(s3Path);
+    }
+
+    @Transactional
+    public void deleteDirectory(String email, String directoryPath) {
+        s3DirectoryRepository.deleteObjectsWithPrefix(
+                givenPathToS3Path(email, directoryPath)
+        );
     }
 }

--- a/back/src/main/java/com/ogjg/back/s3/service/S3DirectoryService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3DirectoryService.java
@@ -1,0 +1,27 @@
+package com.ogjg.back.s3.service;
+
+import com.ogjg.back.s3.repository.S3DirectoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.ogjg.back.common.util.S3PathUtil.givenPathToS3Path;
+
+@Service
+@RequiredArgsConstructor
+public class S3DirectoryService {
+
+    private final S3DirectoryRepository s3DirectoryRepository;
+
+    @Transactional
+    public void createDirectory(String email, String directoryPath) {
+        s3DirectoryRepository.putDirectoryPath(
+                givenPathToS3Path(email, directoryPath)
+        );
+    }
+
+    @Transactional
+    public boolean isDirectoryAlreadyExist(String s3Path) {
+        return s3DirectoryRepository.isDirectoryExist(s3Path);
+    }
+}

--- a/back/src/main/java/com/ogjg/back/s3/service/S3DirectoryService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3DirectoryService.java
@@ -4,6 +4,9 @@ import com.ogjg.back.s3.repository.S3DirectoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+import java.util.List;
 
 import static com.ogjg.back.common.util.S3PathUtil.givenPathToS3Path;
 
@@ -30,5 +33,12 @@ public class S3DirectoryService {
         s3DirectoryRepository.deleteObjectsWithPrefix(
                 givenPathToS3Path(email, directoryPath)
         );
+    }
+
+    @Transactional
+    public void updateDirectoryName(String originS3Prefix, String newS3Prefix) {
+        List<S3Object> objects = s3DirectoryRepository.getObjectsBy(originS3Prefix);
+
+        s3DirectoryRepository.copyAndPasteObjects(objects, originS3Prefix, newS3Prefix);
     }
 }

--- a/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.ogjg.back.common.util.S3PathUtil.createS3PathWithFilePath;
+import static com.ogjg.back.common.util.S3PathUtil.givenPathToS3Path;
 
 @Service
 @RequiredArgsConstructor
@@ -16,20 +16,20 @@ public class S3FileService {
     @Transactional
     public void createFile(String email, String filePath) {
         s3FileRepository.putFilePath(
-                createS3PathWithFilePath(email, filePath)
+                givenPathToS3Path(email, filePath)
         );
     }
 
     @Transactional
     public void deleteFile(String email, String filePath) {
         s3FileRepository.deleteFile(
-                createS3PathWithFilePath(email, filePath)
+                givenPathToS3Path(email, filePath)
         );
     }
     @Transactional
     public void updateFile(String email, String filePath, String content) {
         s3FileRepository.putFile(
-                createS3PathWithFilePath(email, filePath),
+                givenPathToS3Path(email, filePath),
                 content
         );
     }
@@ -37,8 +37,8 @@ public class S3FileService {
     @Transactional
     public void updateFilename(String email, String filePath, String newFilePath) {
         s3FileRepository.rename(
-                createS3PathWithFilePath(email, filePath),
-                createS3PathWithFilePath(email, newFilePath)
+                givenPathToS3Path(email, filePath),
+                givenPathToS3Path(email, newFilePath)
         );
     }
 

--- a/back/src/test/java/com/ogjg/back/common/ControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/common/ControllerTest.java
@@ -3,8 +3,11 @@ package com.ogjg.back.common;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ogjg.back.container.controller.ContainerController;
 import com.ogjg.back.container.service.ContainerService;
+import com.ogjg.back.directory.controller.DirectoryController;
+import com.ogjg.back.directory.service.DirectoryService;
 import com.ogjg.back.file.controller.FileController;
 import com.ogjg.back.file.service.FileService;
+import com.ogjg.back.s3.service.S3DirectoryService;
 import com.ogjg.back.s3.service.S3ProfileImageService;
 import com.ogjg.back.user.controller.UserController;
 import com.ogjg.back.user.service.EmailAuthService;
@@ -27,7 +30,8 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 @WebMvcTest({
         UserController.class,
         ContainerController.class,
-        FileController.class
+        FileController.class,
+        DirectoryController.class
 })
 public class ControllerTest {
 
@@ -62,4 +66,10 @@ public class ControllerTest {
 
     @MockBean
     protected FileService fileService;
+
+    @MockBean
+    protected DirectoryService directoryService;
+
+    @MockBean
+    protected S3DirectoryService s3DirectoryService;
 }

--- a/back/src/test/java/com/ogjg/back/directory/controller/DirectoryControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/directory/controller/DirectoryControllerTest.java
@@ -3,11 +3,13 @@ package com.ogjg.back.directory.controller;
 import com.ogjg.back.common.ControllerTest;
 import com.ogjg.back.directory.dto.request.CreateDirectoryRequest;
 import com.ogjg.back.directory.dto.request.DeleteDirectoryRequest;
+import com.ogjg.back.directory.dto.request.UpdateDirectoryNameRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static com.ogjg.back.common.util.S3PathUtil.createNewFilePath;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
@@ -84,4 +86,39 @@ public class DirectoryControllerTest extends ControllerTest {
                 )
         )).andExpect(status().isOk());
     }
+
+    @DisplayName("디렉토리 이름 수정")
+    @Test
+    public void updateDirectoryName() throws Exception {
+        //given
+        UpdateDirectoryNameRequest request = UpdateDirectoryNameRequest.builder()
+                .directoryPath("/my-container1/hello")
+                .newDirectoryName(createNewFilePath("/my-container1/dog", "hi.txt"))
+                .build();
+
+        doNothing().when(directoryService).updateDirectoryName(any(String.class), any(UpdateDirectoryNameRequest.class));
+
+        //when
+        ResultActions result = this.mockMvc.perform(
+                delete("/api/directories")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        result.andDo(document("directory/rename",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                        fieldWithPath("directoryPath").description("수정할 디렉토리의 기존 전체 경로"),
+                        fieldWithPath("newDirectoryName").description("새로 지은 디렉토리의 이름")
+                ),
+                responseFields(
+                        fieldWithPath("status.code").description("응답 코드"),
+                        fieldWithPath("status.message").description("응답 메시지"),
+                        fieldWithPath("data").description("응답 데이터")
+                )
+        )).andExpect(status().isOk());
+     }
 }

--- a/back/src/test/java/com/ogjg/back/directory/controller/DirectoryControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/directory/controller/DirectoryControllerTest.java
@@ -2,13 +2,16 @@ package com.ogjg.back.directory.controller;
 
 import com.ogjg.back.common.ControllerTest;
 import com.ogjg.back.directory.dto.request.CreateDirectoryRequest;
+import com.ogjg.back.directory.dto.request.DeleteDirectoryRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import static org.mockito.BDDMockito.*;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -48,4 +51,37 @@ public class DirectoryControllerTest extends ControllerTest {
                 )
         )).andExpect(status().isOk());
      }
+
+    @DisplayName("디렉토리 삭제")
+    @Test
+    public void deleteDirectory() throws Exception {
+        //given
+        DeleteDirectoryRequest request = DeleteDirectoryRequest.builder()
+                .directoryPath("/my-container1/hello/")
+                .build();
+
+        doNothing().when(directoryService).deleteDirectory(any(String.class), any(DeleteDirectoryRequest.class));
+
+        //when
+        ResultActions result = this.mockMvc.perform(
+                delete("/api/directories")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        result.andDo(document("directory/delete",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                        fieldWithPath("directoryPath").description("삭제할 디렉토리 전체 경로")
+                ),
+                responseFields(
+                        fieldWithPath("status.code").description("응답 코드"),
+                        fieldWithPath("status.message").description("응답 메시지"),
+                        fieldWithPath("data").description("응답 데이터")
+                )
+        )).andExpect(status().isOk());
+    }
 }

--- a/back/src/test/java/com/ogjg/back/directory/controller/DirectoryControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/directory/controller/DirectoryControllerTest.java
@@ -1,0 +1,51 @@
+package com.ogjg.back.directory.controller;
+
+import com.ogjg.back.common.ControllerTest;
+import com.ogjg.back.directory.dto.request.CreateDirectoryRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class DirectoryControllerTest extends ControllerTest {
+
+    @DisplayName("디렉토리 생성 - 해당 컨테이너가 존재하고, 해당 경로가 존재하지 않는다면 디렉토리를 생성한다.")
+    @Test
+    public void createDirectory() throws Exception {
+        //given
+        CreateDirectoryRequest request = CreateDirectoryRequest.builder()
+                .directoryPath("/my-container1/hello")
+                .build();
+
+        doNothing().when(directoryService).createDirectory(any(String.class), any(CreateDirectoryRequest.class));
+
+        //when
+        ResultActions result = this.mockMvc.perform(
+                post("/api/directories")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        //then
+        result.andDo(document("directory/create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                        fieldWithPath("directoryPath").description("생성할 디렉토리 전체 경로")
+                ),
+                responseFields(
+                        fieldWithPath("status.code").description("응답 코드"),
+                        fieldWithPath("status.message").description("응답 메시지"),
+                        fieldWithPath("data").description("응답 데이터")
+                )
+        )).andExpect(status().isOk());
+     }
+}


### PR DESCRIPTION
###  Feat : OW-65 디렉토리 이름 수정 기능 및 테스트 추가
- [x] 디렉토리 이름 수정 기능 구현
  - 기존 디렉토리를 prefix로 검색해서 해당하는 모든 목록을 rename
  - 각 목록을 새로운 키에 복사하고, 기존 값을 삭제하는 방식
  - Controller 테스트 추가
  - adoc 갱신 및 정리

### Feat : OW-65 디렉토리 삭제 기능 추가
    
- [x] 디렉토리 삭제 기능 구현
  - 해당 prefix를 모두 검사해서 삭제
  - 예외처리
    - 해당 path에 해당하는 컨테이너가 존재하는지 확인
    - 해당 디렉토리가 존재하지 않는다면 예외 던짐
- [x] 테스트 및 문서화 추가
    - Controller 테스트 추가
    - adoc 정리 및 추가된 내용 갱신

### Feat : OW-65 디렉토리 생성 기능 추가
    
- [x] 디렉토리 생성 기능 구현
  - S3로직을 Service, Repository 별로 분리
  - 예외처리
    - 해당 path에 해당하는 컨테이너가 존재하는지 확인
    - 해당 디렉토리가 이미 존재한다면 예외 던짐
- [x] 테스트 및 문서화 추가
  - ControllerTest 추가
  - adoc 정리 및 추가된 내용 갱신