### PR TITLE
Feat : 메인페이지 컨테이너 조회, 수정 API 구현

### DIFF
--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
 
     SUCCESS(HttpStatus.OK, "200", "OK"),
     LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "401", "아이디와 비밀번호를 확인 해주세요"),
+    UNAUTHORIZED_USER_ACCESS(HttpStatus.UNAUTHORIZED, "401", "인가되지 않은 유저의 접근입니다."),
     FAIL_SIGNUP(HttpStatus.BAD_REQUEST, "400", "회원가입에 실패 했습니다"),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "404", "회원를 찾을 수 없습니다"),
     NOT_FOUND_CONTAINER(HttpStatus.NOT_FOUND, "400", "컨테이너를 찾을 수 없습니다"),

--- a/back/src/main/java/com/ogjg/back/container/controller/MainController.java
+++ b/back/src/main/java/com/ogjg/back/container/controller/MainController.java
@@ -1,0 +1,57 @@
+package com.ogjg.back.container.controller;
+
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.response.ApiResponse;
+import com.ogjg.back.config.security.jwt.JwtUserDetails;
+import com.ogjg.back.container.dto.response.ContainersResponse;
+import com.ogjg.back.container.service.ContainerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/main/containers")
+@RequiredArgsConstructor
+public class MainController {
+
+    private final ContainerService containerService;
+
+    @GetMapping("")
+    public ApiResponse<?> getContainers(@RequestParam("search") String query,
+                                        @AuthenticationPrincipal JwtUserDetails userDetails) {
+        List<ContainersResponse> containersResponses = containerService.searchContainers(query, userDetails.getEmail());
+        return new ApiResponse<>(ErrorCode.SUCCESS, containersResponses);
+    }
+
+    @PutMapping("/{containerId}/private")
+    public ApiResponse<?> updatePrivateStatus(@PathVariable Long containerId,
+                                              @AuthenticationPrincipal JwtUserDetails userDetails) {
+        boolean isPrivate = containerService.updatePrivateStatus(containerId, userDetails.getEmail());
+        return new ApiResponse<>(ErrorCode.SUCCESS, new HashMap<>(
+                Map.of("containerId", containerId,
+                        "isPrivate", isPrivate)));
+    }
+
+    @PutMapping("/{containerId}/info")
+    public ApiResponse<?> updateContainerInfo(@PathVariable Long containerId,
+                                              @RequestBody Map<String, String> requestMap,
+                                              @AuthenticationPrincipal JwtUserDetails userDetails) {
+        containerService.updateContainerInfo(containerId, requestMap.get("containerInfo"), userDetails.getEmail());
+        return new ApiResponse<>(ErrorCode.SUCCESS, new HashMap<>(
+                Map.of("containerId", containerId,
+                        "containerInfo", requestMap.get("containerInfo"))));
+    }
+
+    @PutMapping("/{containerId}/pin")
+    public ApiResponse<?> updateContainerInfo(@PathVariable Long containerId,
+                                              @AuthenticationPrincipal JwtUserDetails userDetails) {
+        boolean isPinned = containerService.updatePinStatus(containerId, userDetails.getEmail());
+        return new ApiResponse<>(ErrorCode.SUCCESS, new HashMap<>(
+                Map.of("containerId", containerId,
+                        "pinned", isPinned)));
+    }
+}

--- a/back/src/main/java/com/ogjg/back/container/domain/Container.java
+++ b/back/src/main/java/com/ogjg/back/container/domain/Container.java
@@ -2,6 +2,7 @@ package com.ogjg.back.container.domain;
 
 import com.ogjg.back.chat.domain.Room;
 import com.ogjg.back.user.domain.User;
+import com.ogjg.back.user.exception.UnauthorizedUserAccessException;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
@@ -69,5 +70,26 @@ public class Container {
         this.isPinned = isPinned;
         this.modifiedAt = modifiedAt;
         this.createdAt = createdAt;
+    }
+
+    public void updatePrivate(String email) {
+        checkUserAuthorizationByEmail(email);
+        this.isPrivate = !isPrivate;
+    }
+
+    public void updateDescription(String email, String info) {
+        checkUserAuthorizationByEmail(email);
+        this.description = info;
+    }
+
+    public void updatePinned(String email) {
+        checkUserAuthorizationByEmail(email);
+        this.isPinned = !isPinned;
+    }
+
+    private void checkUserAuthorizationByEmail(String email) {
+        if (!email.equals(user.getEmail())) {
+            throw new UnauthorizedUserAccessException();
+        }
     }
 }

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainersResponse.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainersResponse.java
@@ -1,0 +1,69 @@
+package com.ogjg.back.container.dto.response;
+
+import com.ogjg.back.container.domain.Container;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = PROTECTED)
+public class ContainersResponse {
+
+    private Long containerId;
+    private String name;
+    private String url;
+    private String language;
+    private Long storage;
+    private String info;
+    private LocalDateTime updatedDate;
+    private LocalDateTime createdDate;
+    private boolean pinned;
+    private String owner;
+    private boolean isPrivate;
+    private List<UserImg> usersImg;
+
+    @Builder
+    public ContainersResponse(Container container) {
+        this.containerId = container.getContainerId();
+        this.name = container.getName();
+        this.url = container.getContainerUrl();
+        this.language = container.getLanguage();
+        this.storage = container.getAvailableStorage();
+        this.info = container.getDescription();
+        this.updatedDate = container.getModifiedAt();
+        this.createdDate = container.getCreatedAt();
+        this.pinned = container.getIsPinned();
+        this.owner = container.getUser().getEmail();
+        this.isPrivate = container.getIsPrivate();
+        this.usersImg = new ArrayList<>(
+                List.of(UserImg.builder()
+                        .email(container.getUser().getEmail())
+                        .userName(container.getUser().getName())
+                        .imgUrl(container.getUser().getUserImg())
+                        .build())
+        );
+    }
+
+    @Getter
+    @Setter
+    public static class UserImg {
+        private String email;
+        private String imgUrl;
+        private String userName;
+
+        @Builder
+        public UserImg(String email, String imgUrl, String userName) {
+            this.email = email;
+            this.imgUrl = imgUrl;
+            this.userName = userName;
+        }
+    }
+}

--- a/back/src/main/java/com/ogjg/back/container/repository/ContainerRepository.java
+++ b/back/src/main/java/com/ogjg/back/container/repository/ContainerRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ContainerRepository extends JpaRepository<Container, Long> {
@@ -19,4 +20,8 @@ public interface ContainerRepository extends JpaRepository<Container, Long> {
             @Param("containerName") String containerName,
             @Param("email")String email
     );
+
+    List<Container> findAllByName(String email);
+
+    List<Container> findAllByNameContainingAndUserEmail(String query, String email);
 }

--- a/back/src/main/java/com/ogjg/back/user/domain/User.java
+++ b/back/src/main/java/com/ogjg/back/user/domain/User.java
@@ -1,10 +1,13 @@
 package com.ogjg.back.user.domain;
 
+import com.ogjg.back.container.domain.Container;
 import com.ogjg.back.user.dto.SignUpSaveDto;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -21,6 +24,9 @@ public class User {
     private String name;
 
     private String userImg;
+
+    @OneToMany(mappedBy = "user")
+    private List<Container> containers;
 
     @Enumerated(EnumType.STRING)
     private UserStatus userStatus = UserStatus.ACTIVE;

--- a/back/src/main/java/com/ogjg/back/user/exception/UnauthorizedUserAccessException.java
+++ b/back/src/main/java/com/ogjg/back/user/exception/UnauthorizedUserAccessException.java
@@ -1,0 +1,20 @@
+package com.ogjg.back.user.exception;
+
+import com.ogjg.back.common.exception.CustomException;
+import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorData;
+
+public class UnauthorizedUserAccessException extends CustomException {
+
+    public UnauthorizedUserAccessException() {
+        super(ErrorCode.UNAUTHORIZED_USER_ACCESS);
+    }
+
+    public UnauthorizedUserAccessException(String message) {
+        super(ErrorCode.UNAUTHORIZED_USER_ACCESS, message);
+    }
+
+    public UnauthorizedUserAccessException(ErrorData errorData) {
+        super(ErrorCode.UNAUTHORIZED_USER_ACCESS, errorData);
+    }
+}


### PR DESCRIPTION
## API
- 메인 페이지에서 컨테이너 접근을 위한 조회 API 구현
- 컨테이너의 상태(공개, 고정, 설명) 수정을 위한 API 구현

## Exception
- 인가되지 않은 사용자가 접근할 때 발생시키기 위한 예외 작성

## Fix
- container에 대한 관계(@OneToMany) 추가