### PR TITLE
Fix : ErrorCode changeMessage 버그 수정

### DIFF
--- a/back/src/main/java/com/ogjg/back/common/exception/CustomException.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/CustomException.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public abstract class CustomException extends RuntimeException {
 
-    private final ErrorCode errorCode;
+    private final ErrorType errorCode;
     private ErrorData errorData;
 
     public CustomException(

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum ErrorCode {
+public enum ErrorCode implements ErrorType {
 
     SUCCESS(HttpStatus.OK, "200", "OK"),
     LOGIN_FAIL(HttpStatus.UNAUTHORIZED, "401", "아이디와 비밀번호를 확인 해주세요"),
@@ -39,11 +39,10 @@ public enum ErrorCode {
         this.message = message;
     }
 
-    public ErrorCode changeMessage(
+    public ErrorResult changeMessage(
             String message
     ) {
-        this.message = message;
-        return this;
+        return new ErrorResult(this.statusCode, this.getCode(), message);
     }
 
 }

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorResult.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorResult.java
@@ -1,0 +1,18 @@
+package com.ogjg.back.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+class ErrorResult implements ErrorType {
+
+    private final HttpStatus statusCode;
+    private final String code;
+    private final String message;
+
+    public ErrorResult(HttpStatus statusCode, String code, String message) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorType.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorType.java
@@ -1,0 +1,13 @@
+package com.ogjg.back.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorType {
+
+    HttpStatus getStatusCode();
+
+    String getCode();
+
+    String getMessage();
+
+}

--- a/back/src/main/java/com/ogjg/back/common/response/ApiResponse.java
+++ b/back/src/main/java/com/ogjg/back/common/response/ApiResponse.java
@@ -1,6 +1,6 @@
 package com.ogjg.back.common.response;
 
-import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorType;
 import com.ogjg.back.common.response.dto.Status;
 import lombok.Getter;
 
@@ -11,11 +11,11 @@ public class ApiResponse<T> {
 
     private T data;
 
-    public ApiResponse(ErrorCode errorCode) {
+    public ApiResponse(ErrorType errorCode) {
         this.status = new Status(errorCode);
     }
 
-    public ApiResponse(ErrorCode errorCode, T data) {
+    public ApiResponse(ErrorType errorCode, T data) {
         this.status = new Status(errorCode);
         this.data = data;
     }

--- a/back/src/main/java/com/ogjg/back/common/response/ErrorResponse.java
+++ b/back/src/main/java/com/ogjg/back/common/response/ErrorResponse.java
@@ -1,15 +1,15 @@
 package com.ogjg.back.common.response;
 
-import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.exception.ErrorData;
+import com.ogjg.back.common.exception.ErrorType;
 
 public class ErrorResponse extends ApiResponse<ErrorData> {
 
-    public ErrorResponse(ErrorCode errorCode) {
+    public ErrorResponse(ErrorType errorCode) {
         super(errorCode);
     }
 
-    public ErrorResponse(ErrorCode errorCode, ErrorData errorData) {
+    public ErrorResponse(ErrorType errorCode, ErrorData errorData) {
         super(errorCode, errorData);
     }
 

--- a/back/src/main/java/com/ogjg/back/common/response/dto/Status.java
+++ b/back/src/main/java/com/ogjg/back/common/response/dto/Status.java
@@ -1,7 +1,7 @@
 package com.ogjg.back.common.response.dto;
 
 
-import com.ogjg.back.common.exception.ErrorCode;
+import com.ogjg.back.common.exception.ErrorType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,7 +11,7 @@ public class Status {
     private String code;
     private String message;
 
-    public Status(ErrorCode errorCode) {
+    public Status(ErrorType errorCode) {
         this.code = errorCode.getCode();
         this.message = errorCode.getMessage();
     }


### PR DESCRIPTION
### ErrorCode의 changeMessage를 사용한다면 기존에 정의해둔 메시지가 changeMessage를 사용한 메시지로 영구적으로 변경됨을 확인
- 기존의 코드변경이 생기지 않도록 메시지를 변경할 시  ErrorResult라는 메시지만 변경된 새로운 객체를 생성하여 반환
- ErrorType 부모 interface 생성
- ErrorCode, ErrorResult에 상속 받아 사용