### PR TITLE
Feat : OW-87 파일 응답 데이터에 uuid 키 값 추가

### DIFF
--- a/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
+++ b/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
@@ -57,4 +57,21 @@ public class S3PathUtil {
     public static String createNewKey(String originPrefix, String newS3Path, S3Object s3Object) {
         return newS3Path + s3Object.key().substring(originPrefix.length());
     }
+
+    public static String extractFileName(String filePath) {
+        int lastIndex = filePath.lastIndexOf(DELIMITER);
+        return filePath.substring(lastIndex + 1);
+    }
+
+    public static String extractFilePrefix(String filePath) {
+        int lastIndex = filePath.lastIndexOf(DELIMITER);
+        return filePath.substring(0, lastIndex + 1);
+    }
+
+    public static String extractKeyPrefix(String filePath) {
+        int lastIndex = filePath.lastIndexOf(DELIMITER);
+        return filePath.substring(0, lastIndex + 1);
+    }
+
+
 }

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainerGetFileResponse.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainerGetFileResponse.java
@@ -11,10 +11,12 @@ import static lombok.AccessLevel.PROTECTED;
 public class ContainerGetFileResponse {
     private String filePath;
     private String content;
+    private String uuid;
 
     @Builder
-    public ContainerGetFileResponse(String filePath, String content) {
+    public ContainerGetFileResponse(String filePath, String content, String uuid) {
         this.filePath = filePath;
         this.content = content;
+        this.uuid = uuid;
     }
 }

--- a/back/src/main/java/com/ogjg/back/file/domain/File.java
+++ b/back/src/main/java/com/ogjg/back/file/domain/File.java
@@ -35,4 +35,9 @@ public class File {
         this.name = name;
         this.path = path;
     }
+
+    public File rename(String newFilename) {
+        this.name = newFilename;
+        return this;
+    }
 }

--- a/back/src/main/java/com/ogjg/back/file/domain/File.java
+++ b/back/src/main/java/com/ogjg/back/file/domain/File.java
@@ -1,0 +1,38 @@
+package com.ogjg.back.file.domain;
+
+import com.ogjg.back.container.domain.Container;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class File {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    private String uuid;
+
+    @ManyToOne
+    @JoinColumn(name = "containerId")
+    private Container container;
+
+    private String name;
+
+    private String path;
+
+    @Builder
+    public File(String uuid, Container container, String name, String path) {
+        this.uuid = uuid;
+        this.container = container;
+        this.name = name;
+        this.path = path;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/file/repository/FileRepository.java
+++ b/back/src/main/java/com/ogjg/back/file/repository/FileRepository.java
@@ -1,0 +1,8 @@
+package com.ogjg.back.file.repository;
+
+import com.ogjg.back.file.domain.S3PathMap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface S3PathMapRepository extends JpaRepository<S3PathMap, String> {
+
+}

--- a/back/src/main/java/com/ogjg/back/file/repository/FileRepository.java
+++ b/back/src/main/java/com/ogjg/back/file/repository/FileRepository.java
@@ -1,8 +1,19 @@
 package com.ogjg.back.file.repository;
 
-import com.ogjg.back.file.domain.S3PathMap;
+import com.ogjg.back.file.domain.File;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface S3PathMapRepository extends JpaRepository<S3PathMap, String> {
+import java.util.Optional;
 
+public interface FileRepository extends JpaRepository<File, String> {
+
+    @Query("""
+    select f.uuid from File f join f.container c on f.container.containerId = c.containerId
+    where c.containerId = :containerId
+    and f.path = :key
+    and f.name = :filename
+""")
+    Optional<String> findUuid(@Param("containerId") Long containerId, @Param("key") String key, @Param("filename") String filename);
 }

--- a/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
@@ -119,6 +119,7 @@ public class ContainerControllerTest extends ControllerTest {
                 .map((key) -> ContainerGetFileResponse.builder()
                         .filePath(key)
                         .content("temp data")
+                        .uuid("temp uuid")
                         .build())
                 .toList();
 
@@ -165,6 +166,7 @@ public class ContainerControllerTest extends ControllerTest {
                                 fieldWithPath("data.fileData[]").description("모든 파일 데이터"),
                                 fieldWithPath("data.fileData[].filePath").description("파일 경로"),
                                 fieldWithPath("data.fileData[].content").description("파일 내용"),
+                                fieldWithPath("data.fileData[].uuid").description("파일 uuid"),
                                 fieldWithPath("data.directories").description("모든 디렉토리 경로")
                         )
                 )

--- a/back/src/test/java/com/ogjg/back/file/controller/FileControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/file/controller/FileControllerTest.java
@@ -18,7 +18,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class FileControllerTest extends ControllerTest {
+public class S3PathMapControllerTest extends ControllerTest {
 
     @DisplayName("파일 생성")
     @Test

--- a/back/src/test/java/com/ogjg/back/file/controller/FileControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/file/controller/FileControllerTest.java
@@ -18,7 +18,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class S3PathMapControllerTest extends ControllerTest {
+public class FileControllerTest extends ControllerTest {
 
     @DisplayName("파일 생성")
     @Test


### PR DESCRIPTION
 crdt 기능 추가로 인한 요구사항 변경으로 uuid 값을 추가해야할 필요가 생겼습니다.
  - 디렉토리, 파일에 대한 새로운 키(uuid) 값이 필요한데, 우선 File 관련 정보가 우선적으로 필요해서 해당 부분만 먼저 추가하기로 했습니다.
  - 그래서 테이블 이름도 File로 하였고, File 경로만 저장하도록 했습니다.

### Feat : OW-87 File entity 추가
- [x] File 엔티티 추가
  - 네이밍이나 내용을 손봐야 할 것 같습니다.
### Feat : OW-87 파일 응답 데이터에 uuid 키 값 추가
    
- [x] 모든 컨테이너 구조 불러오기 api 수정
  - ContainerGetFileResponse에 uuid 추가
  - fileData 생성 로직 수정. uuid를 fileRepository로 조회해서 매핑
- [x] 해당 ControllerTest 응답 값 수정
- [x] 파일 관련 api에 db 반영 로직 추가
  - 파일 생성 시 내용이 없는 빈 파일로 생성하도록 수정
  - 파일 생성 시 DB에 파일 정보 저장
  - 파일 제거 시 DB에서 파일 정보 삭제
  - 파일 이름 수정 시 DB에 filename 수정
