### PR TITLE
Feat : OW-81 컨테이너 삭제 API 구현

### DIFF
--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -58,6 +58,14 @@ include::{snippets}/container/create/request-fields.adoc[]
 
 include::{snippets}/container/create/http-response.adoc[]
 
+=== 컨테이너 삭제
+ID에 해당하는 컨테이너를 삭제합니다.
+
+include::{snippets}/container/delete/http-request.adoc[]
+include::{snippets}/container/delete/path-parameters.adoc[]
+
+include::{snippets}/container/delete/http-response.adoc[]
+
 === 컨테이너 이름 중복체크
 컨테이너 생성 시에 중복되는 컨테이너 이름이 없는지 검사합니다.
 

--- a/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
+++ b/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
@@ -10,7 +10,7 @@ public class S3PathUtil {
     /**
      * email을 s3 prefix로 사용하기 위해 특수문자를 '-'로 대체한다.
      */
-    public static String createS3Directory(String loginEmail, String containerName) {
+    public static String createContainerPrefix(String loginEmail, String containerName) {
         loginEmail = loginEmail
                 .replace('.', S3_EMAIL_DELIMETER)
                 .replace('@', S3_EMAIL_DELIMETER);

--- a/back/src/main/java/com/ogjg/back/container/controller/ContainerController.java
+++ b/back/src/main/java/com/ogjg/back/container/controller/ContainerController.java
@@ -28,6 +28,21 @@ public class ContainerController {
     }
 
     /**
+     * 컨테이너 삭제
+     */
+    @DeleteMapping("/{containerId}")
+    public ApiResponse<ContainerGetResponse> deleteContainer(
+            @PathVariable("containerId") Long containerId
+    ) {
+        String loginEmail = "ogjg1234@naver.com";
+
+        containerService.deleteContainer(containerId, loginEmail);
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS
+        );
+    }
+
+    /**
      * 컨테이너 이름 중복체크
      */
     @GetMapping("/check")

--- a/back/src/main/java/com/ogjg/back/file/service/FileService.java
+++ b/back/src/main/java/com/ogjg/back/file/service/FileService.java
@@ -22,7 +22,7 @@ import static com.ogjg.back.common.util.S3PathUtil.*;
 public class FileService {
     private final ContainerRepository containerRepository;
     private final FileRepository fileRepository;
-    private final S3FileService s3PathService;
+    private final S3FileService s3FileService;
 
     @Transactional
     public void createFile(String loginEmail, String filePath, String uuid) {
@@ -30,7 +30,7 @@ public class FileService {
 
         String containerName = extractContainerName(filePath);
         if (!isContainerExist(loginEmail, containerName)) throw new NotFoundContainer();
-        if (s3PathService.isFileAlreadyExist(s3Path)) throw new FileAlreadyExists();
+        if (s3FileService.isFileAlreadyExist(s3Path)) throw new FileAlreadyExists();
 
         Container container = findContainerByNameAndEmail(containerName, loginEmail);
 
@@ -41,7 +41,7 @@ public class FileService {
                 .uuid(uuid)
                 .build());
 
-        s3PathService.createFile(loginEmail, filePath);
+        s3FileService.createFile(loginEmail, filePath);
     }
 
     @Transactional
@@ -50,7 +50,7 @@ public class FileService {
         String containerName = extractContainerName(filePath);
 
 //        if (!isContainerExist(loginEmail, containerName)) throw new NotFoundContainer();
-        if (!s3PathService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
+        if (!s3FileService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
 
         // db 삭제
         Container container = findContainerByNameAndEmail(containerName, loginEmail);
@@ -61,7 +61,7 @@ public class FileService {
         fileRepository.delete(findFile);
 
         // s3 삭제
-        s3PathService.deleteFile(loginEmail, filePath);
+        s3FileService.deleteFile(loginEmail, filePath);
     }
 
     @Transactional
@@ -69,9 +69,9 @@ public class FileService {
         String s3Path = givenPathToS3Path(loginEmail, filePath);
 
         if (!isContainerExist(loginEmail, extractContainerName(filePath))) throw new NotFoundContainer();
-        if (!s3PathService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
+        if (!s3FileService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
 
-        s3PathService.updateFile(loginEmail, filePath, request.getContent());
+        s3FileService.updateFile(loginEmail, filePath, request.getContent());
     }
 
     @Transactional
@@ -81,7 +81,7 @@ public class FileService {
         String containerName = extractContainerName(filePath);
 
 //        if (!isContainerExist(loginEmail, containerName)) throw new NotFoundContainer();
-        if (!s3PathService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
+        if (!s3FileService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
 
         // db rename
         Container container = findContainerByNameAndEmail(containerName, loginEmail);
@@ -92,7 +92,7 @@ public class FileService {
         findFile.rename(newFilename);
 
         // s3 rename
-        s3PathService.updateFilename(loginEmail, filePath, newFilePath);
+        s3FileService.updateFilename(loginEmail, filePath, newFilePath);
     }
 
     private boolean isContainerExist(String loginEmail, String containerName) {

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3ContainerRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3ContainerRepository.java
@@ -68,4 +68,27 @@ public class S3ContainerRepository {
 
         return s3Client.getObject(getObjectRequest, ResponseTransformer.toBytes()).asUtf8String();
     }
+
+    public void deleteObjectsWithPrefix(String prefix) {
+        try {
+            ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder()
+                    .bucket(bucketName)
+                    .prefix(prefix)
+                    .build();
+
+            s3Client.listObjectsV2(listObjectsV2Request).contents().stream()
+                    .map((content) -> toDeleteObjectRequest(content))
+                    .forEach((request) -> s3Client.deleteObject(request));
+
+        } catch (Exception e) {
+            log.error("error message={}",e.getMessage());
+        }
+    }
+
+    private DeleteObjectRequest toDeleteObjectRequest(S3Object content) {
+        return DeleteObjectRequest.builder()
+                .bucket(bucketName)
+                .key(content.key())
+                .build();
+    }
 }

--- a/back/src/main/java/com/ogjg/back/s3/service/S3ContainerService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3ContainerService.java
@@ -77,9 +77,15 @@ public class S3ContainerService {
      * 컨테이너 모든 구조 가져오기 - 디렉토리 데이터 생성
      * 이메일 경로를 제외한 구조를 응답값에 포함해야 하므로 절삭된 키 사용
      */
+    @Transactional(readOnly = true)
     public List<String> getDirectories(List<String> parsedKeys) {
         return parsedKeys.stream()
                 .filter((key) -> !isFile(key))
                 .toList();
+    }
+
+    @Transactional
+    public void deleteAllByPrefix(String prefix) {
+        s3ContainerRepository.deleteObjectsWithPrefix(prefix);
     }
 }

--- a/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
@@ -16,8 +16,7 @@ import java.util.List;
 
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -38,7 +37,7 @@ public class ContainerControllerTest extends ControllerTest {
 
         doNothing()
                 .when(containerService)
-                .createContainer(any(String.class), eq(request));
+                .createContainer(anyString(), eq(request));
 
         // when
         ResultActions result = this.mockMvc.perform(
@@ -61,6 +60,37 @@ public class ContainerControllerTest extends ControllerTest {
         )).andExpect(status().isOk());
      }
 
+    @DisplayName("컨테이너 삭제")
+    @Test
+    public void deleteContainer() throws Exception {
+        //given
+        ContainerCreateRequest request = ContainerCreateRequest.builder()
+                .name("이회장")
+                .description("자바 연습 할거야")
+                .isPrivate(false)
+                .language("Java")
+                .build();
+
+        doNothing()
+                .when(containerService)
+                .deleteContainer(anyLong(), anyString());
+
+        // when
+        ResultActions result = this.mockMvc.perform(
+                delete("/api/containers/{containerId}", 1L)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andDo(document("container/delete",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("containerId").description("컨테이너 ID")
+                )
+        )).andExpect(status().isOk());
+    }
+
     @DisplayName("컨테이너 이름 중복 체크")
     @Test
     public void checkDuplication() throws Exception {
@@ -69,7 +99,7 @@ public class ContainerControllerTest extends ControllerTest {
                 .isDuplicated(true)
                 .build();
 
-        given(containerService.checkDuplication(any(String.class), any(String.class)))
+        given(containerService.checkDuplication(anyString(), anyString()))
                 .willReturn(response);
 
         // when
@@ -130,7 +160,7 @@ public class ContainerControllerTest extends ControllerTest {
                 .directories(directories)
                 .build();
 
-        given(containerService.getAllFilesAndDirectories(any(Long.class), any(String.class)))
+        given(containerService.getAllFilesAndDirectories(anyLong(), anyString()))
                 .willReturn(response);
 
         //when


### PR DESCRIPTION
- [x] 컨테이너 삭제 기능 구현
  - S3PathUtil의 이메일과 컨테이너를 조합해서 prefix를 만드는 기능 이름 수정
  - prefix를 이용해서 해당 컨테이너를 하위 내용까지 삭제
  - db, s3 모두 반영
- [x] 컨테이너 삭제 기능 문서화 추가
 - 해당 ControllerTest 추가
 - anyString, anyLong 사용하도록 수정
 - adoc 작성