### PR TITLE
Feat : OW-95 메인 페이지 컨테이너 조회 오류 수정 및 Directory uuid 추가

### DIFF
--- a/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
+++ b/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
@@ -48,9 +48,7 @@ public class S3PathUtil {
     }
 
     public static String createNewDirectoryPath(String originPath, String newFilename) {
-        String temp = originPath.substring(0, originPath.length() - 1);
-        int secondLastDelimiterIndex = temp.lastIndexOf(DELIMITER);
-
+        int secondLastDelimiterIndex = findSecondLastDelimiterIndex(originPath);
         return originPath.substring(0, secondLastDelimiterIndex) + DELIMITER + newFilename + DELIMITER;
     }
 
@@ -58,7 +56,7 @@ public class S3PathUtil {
         return newS3Path + s3Object.key().substring(originPrefix.length());
     }
 
-    public static String extractFileName(String filePath) {
+    public static String extractFilename(String filePath) {
         int lastIndex = filePath.lastIndexOf(DELIMITER);
         return filePath.substring(lastIndex + 1);
     }
@@ -68,11 +66,15 @@ public class S3PathUtil {
         return filePath.substring(0, lastIndex + 1);
     }
 
-    public static String extractKeyPrefix(String filePath) {
-        int lastIndex = filePath.lastIndexOf(DELIMITER);
-        return filePath.substring(0, lastIndex + 1);
+    public static String extractDirectoryPrefix(String directoryPath) {
+        int secondLastDelimiterIndex = findSecondLastDelimiterIndex(directoryPath);
+        return directoryPath.substring(0, secondLastDelimiterIndex + 1);
     }
 
+    public static String extractDirectoryName(String directoryPath) {
+        int secondLastDelimiterIndex = findSecondLastDelimiterIndex(directoryPath);
+        return directoryPath.substring(secondLastDelimiterIndex + 1);
+    }
 
     public static String createImagePrefix(String email) {
         return DELIMITER + email + DELIMITER + "image.";
@@ -81,6 +83,10 @@ public class S3PathUtil {
     public static String extractExtension(String originalName) {
         int index = originalName.lastIndexOf('.');
         return originalName.substring(index + 1); // .제외한 확장자만 추출한다.
+    }
 
+    private static int findSecondLastDelimiterIndex(String directoryPath) {
+        String temp = directoryPath.substring(0, directoryPath.length() - 1);
+        return temp.lastIndexOf(DELIMITER);
     }
 }

--- a/back/src/main/java/com/ogjg/back/container/domain/Container.java
+++ b/back/src/main/java/com/ogjg/back/container/domain/Container.java
@@ -1,7 +1,7 @@
 package com.ogjg.back.container.domain;
 
 import com.ogjg.back.chat.domain.Room;
-import com.ogjg.back.file.domain.File;
+import com.ogjg.back.file.domain.Path;
 import com.ogjg.back.file.exception.NotFoundFile;
 import com.ogjg.back.user.domain.User;
 import com.ogjg.back.user.exception.UnauthorizedUserAccessException;
@@ -36,7 +36,7 @@ public class Container {
     private Room room;
 
     @OneToMany(mappedBy = "container")
-    private List<File> files = new ArrayList<>();
+    private List<Path> paths = new ArrayList<>();
 
     @Pattern(regexp = "^[a-zA-Z0-9\\-_]{1,20}$",
             message = "컨테이너 이름에는 영문, 숫자가 포함가능하며, 특수문자는 '-', '_'만 포함될 수 있습니다.")
@@ -65,11 +65,11 @@ public class Container {
     private LocalDateTime createdAt;
 
     @Builder
-    public Container(Long containerId, User user, Room room, List<File> files, String name, String description, String language, String containerUrl, Boolean isPrivate, Long availableStorage, Boolean isPinned, LocalDateTime modifiedAt, LocalDateTime createdAt) {
+    public Container(Long containerId, User user, Room room, List<Path> paths, String name, String description, String language, String containerUrl, Boolean isPrivate, Long availableStorage, Boolean isPinned, LocalDateTime modifiedAt, LocalDateTime createdAt) {
         this.containerId = containerId;
         this.user = user;
         this.room = room;
-        this.files = files;
+        this.paths = paths;
         this.name = name;
         this.description = description;
         this.language = language;
@@ -102,11 +102,12 @@ public class Container {
         }
     }
 
-    public File findFileByPrefix(String filePath) {
+    public Path findPath(String filePath, String name) {
         // todo: 1) s3와 구분되는 에러코드 고려하기
         //       2) 쿼리문 활용 최적화 필요
-        return files.stream()
+        return paths.stream()
                 .filter((file -> file.getPath().equals(filePath)))
+                .filter((file -> file.getName().equals(name)))
                 .findAny()
                 .orElseThrow(() -> new NotFoundFile("DB에 존재하지 않는 파일입니다."));
     }

--- a/back/src/main/java/com/ogjg/back/container/dto/request/ContainerGetDirectoryResponse.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/request/ContainerGetDirectoryResponse.java
@@ -1,0 +1,20 @@
+package com.ogjg.back.container.dto.request;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ContainerGetDirectoryResponse {
+    private String directory;
+    private String uuid;
+
+    @Builder
+    public ContainerGetDirectoryResponse(String directory, String uuid) {
+        this.directory = directory;
+        this.uuid = uuid;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainerGetResponse.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainerGetResponse.java
@@ -1,5 +1,6 @@
 package com.ogjg.back.container.dto.response;
 
+import com.ogjg.back.container.dto.request.ContainerGetDirectoryResponse;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,14 +16,14 @@ public class ContainerGetResponse {
     private String language;
     private ContainerGetNodeResponse treeData;
     private List<ContainerGetFileResponse> fileData;
-    private List<String> directories;
+    private List<ContainerGetDirectoryResponse> directories;
 
     @Builder
     public ContainerGetResponse(
             String language,
             ContainerGetNodeResponse treeData,
             List<ContainerGetFileResponse> fileData,
-            List<String> directories
+            List<ContainerGetDirectoryResponse> directories
     ) {
         this.language = language;
         this.treeData = treeData;

--- a/back/src/main/java/com/ogjg/back/container/service/ContainerService.java
+++ b/back/src/main/java/com/ogjg/back/container/service/ContainerService.java
@@ -11,7 +11,7 @@ import com.ogjg.back.container.exception.NotFoundContainer;
 import com.ogjg.back.container.repository.ContainerRepository;
 import com.ogjg.back.directory.exception.NotFoundDirectory;
 import com.ogjg.back.file.exception.NotFoundFile;
-import com.ogjg.back.file.repository.FileRepository;
+import com.ogjg.back.file.repository.PathRepository;
 import com.ogjg.back.s3.repository.S3ContainerRepository;
 import com.ogjg.back.s3.service.S3ContainerService;
 import com.ogjg.back.s3.service.S3DirectoryService;
@@ -33,7 +33,7 @@ import static com.ogjg.back.common.util.S3PathUtil.*;
 public class ContainerService {
     private final UserRepository userRepository;
     private final ContainerRepository containerRepository;
-    private final FileRepository fileRepository;
+    private final PathRepository pathRepository;
     private final S3ContainerService s3ContainerService;
     private final S3ContainerRepository s3ContainerRepository;
     private final S3DirectoryService s3DirectoryService;
@@ -105,12 +105,12 @@ public class ContainerService {
                 .map((key) -> ContainerGetFileResponse.builder()
                         .filePath(createEmailRemovedKey(key, loginEmail))
                         .content(s3ContainerRepository.getFileContent(key))
-                        .uuid(fileRepository.findUuid(
+                        .uuid(pathRepository.findUuid(
                                 containerId,
-                                extractKeyPrefix(
+                                extractFilePrefix(
                                         createEmailRemovedKey(key, loginEmail)
                                 ),
-                                extractFileName(key)
+                                extractFilename(key)
                         ).orElseThrow(() -> new NotFoundFile("존재하지 않는 파일입니다. containerId="+ containerId +", key ="+ extractFilePrefix(key))))
                         .build())
                 .toList();

--- a/back/src/main/java/com/ogjg/back/directory/repository/DirectoryRepository.java
+++ b/back/src/main/java/com/ogjg/back/directory/repository/DirectoryRepository.java
@@ -1,0 +1,7 @@
+package com.ogjg.back.directory.repository;
+
+import com.ogjg.back.file.domain.Path;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DirectoryRepository extends JpaRepository<Path, String> {
+}

--- a/back/src/main/java/com/ogjg/back/directory/service/DirectoryService.java
+++ b/back/src/main/java/com/ogjg/back/directory/service/DirectoryService.java
@@ -1,10 +1,14 @@
 package com.ogjg.back.directory.service;
 
+import com.ogjg.back.container.domain.Container;
 import com.ogjg.back.container.exception.NotFoundContainer;
 import com.ogjg.back.container.repository.ContainerRepository;
 import com.ogjg.back.directory.dto.request.CreateDirectoryRequest;
 import com.ogjg.back.directory.exception.DirectoryAlreadyExists;
 import com.ogjg.back.directory.exception.NotFoundDirectory;
+import com.ogjg.back.directory.repository.DirectoryRepository;
+import com.ogjg.back.file.domain.Path;
+import com.ogjg.back.file.repository.PathRepository;
 import com.ogjg.back.s3.service.S3DirectoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,13 +24,25 @@ public class DirectoryService {
 
     private final ContainerRepository containerRepository;
     private final S3DirectoryService s3DirectoryService;
+    private final DirectoryRepository directoryRepository;
+    private final PathRepository pathRepository;
 
     @Transactional
     public void createDirectory(String loginEmail, String directoryPath, CreateDirectoryRequest request) {
         String s3Path = givenPathToS3Path(loginEmail, directoryPath);
 
-        if (!isContainerExist(loginEmail, extractContainerName(directoryPath))) throw new NotFoundContainer();
+        String containerName = extractContainerName(directoryPath);
+        if (!isContainerExist(loginEmail, containerName)) throw new NotFoundContainer();
         if (s3DirectoryService.isDirectoryAlreadyExist(s3Path)) throw new DirectoryAlreadyExists();
+
+        Container container = findContainerByNameAndEmail(containerName, loginEmail);
+
+        directoryRepository.save(Path.builder()
+                .container(container)
+                .path(extractDirectoryPrefix(directoryPath))
+                .name(extractDirectoryName(directoryPath))
+                .uuid(request.getUuid())
+                .build());
 
         s3DirectoryService.createDirectory(loginEmail, directoryPath);
     }
@@ -34,9 +50,19 @@ public class DirectoryService {
     @Transactional
     public void deleteDirectory(String loginEmail, String directoryPath) {
         String s3Path = givenPathToS3Path(loginEmail, directoryPath);
+        String containerName = extractContainerName(directoryPath);
 
-        if (!isContainerExist(loginEmail, extractContainerName(directoryPath))) throw new NotFoundContainer();
+        if (!isContainerExist(loginEmail, containerName)) throw new NotFoundContainer();
         if (!s3DirectoryService.isDirectoryAlreadyExist(s3Path)) throw new NotFoundDirectory();
+
+        // db 삭제
+        Container container = findContainerByNameAndEmail(containerName, loginEmail);
+
+        Path findPath = container.findPath(
+                extractDirectoryPrefix(directoryPath),
+                extractDirectoryName(directoryPath)
+        );
+        pathRepository.delete(findPath);
 
         s3DirectoryService.deleteDirectory(loginEmail, directoryPath);
     }
@@ -45,9 +71,19 @@ public class DirectoryService {
     public void updateDirectoryName(String loginEmail, String directoryPath, String newDirectoryName) {
         String originS3Path = givenPathToS3Path(loginEmail, directoryPath);
         String newS3Path = createNewDirectoryPath(originS3Path, newDirectoryName);
+        String containerName = extractContainerName(directoryPath);
 
-        if (!isContainerExist(loginEmail, extractContainerName(directoryPath))) throw new NotFoundContainer();
+        if (!isContainerExist(loginEmail, containerName)) throw new NotFoundContainer();
         if (!s3DirectoryService.isDirectoryAlreadyExist(originS3Path)) throw new NotFoundDirectory();
+
+        // db rename
+        Container container = findContainerByNameAndEmail(containerName, loginEmail);
+
+        Path findPath = container.findPath(
+                extractDirectoryPrefix(directoryPath),
+                extractDirectoryName(directoryPath)
+        );
+        findPath.rename(newDirectoryName);
 
         s3DirectoryService.updateDirectoryName(originS3Path, newS3Path);
     }
@@ -55,5 +91,11 @@ public class DirectoryService {
     private boolean isContainerExist(String loginEmail, String containerName) {
         return containerRepository.findByNameAndEmail(containerName, loginEmail)
                 .isPresent();
+    }
+
+    private Container findContainerByNameAndEmail(String containerName, String loginEmail) {
+        Container container = containerRepository.findByNameAndEmail(containerName, loginEmail)
+                .orElseThrow(NotFoundContainer::new);
+        return container;
     }
 }

--- a/back/src/main/java/com/ogjg/back/file/domain/Path.java
+++ b/back/src/main/java/com/ogjg/back/file/domain/Path.java
@@ -12,7 +12,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class File {
+public class Path {
 
     @Id
     @GeneratedValue(strategy = IDENTITY)
@@ -29,14 +29,14 @@ public class File {
     private String path;
 
     @Builder
-    public File(String uuid, Container container, String name, String path) {
+    public Path(String uuid, Container container, String name, String path) {
         this.uuid = uuid;
         this.container = container;
         this.name = name;
         this.path = path;
     }
 
-    public File rename(String newFilename) {
+    public Path rename(String newFilename) {
         this.name = newFilename;
         return this;
     }

--- a/back/src/main/java/com/ogjg/back/file/domain/Path.java
+++ b/back/src/main/java/com/ogjg/back/file/domain/Path.java
@@ -40,4 +40,9 @@ public class Path {
         this.name = newFilename;
         return this;
     }
+
+    public Path renameAncestor(String ancestorPath, String newAncestorPath) {
+        this.path = this.path.replace(ancestorPath, newAncestorPath);
+        return this;
+    }
 }

--- a/back/src/main/java/com/ogjg/back/file/repository/PathRepository.java
+++ b/back/src/main/java/com/ogjg/back/file/repository/PathRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PathRepository extends JpaRepository<Path, String> {
@@ -16,4 +17,6 @@ public interface PathRepository extends JpaRepository<Path, String> {
     and p.name = :filename
 """)
     Optional<String> findUuid(@Param("containerId") Long containerId, @Param("key") String key, @Param("filename") String filename);
+
+    List<Path> findByPathStartsWith(String prefix);
 }

--- a/back/src/main/java/com/ogjg/back/file/repository/PathRepository.java
+++ b/back/src/main/java/com/ogjg/back/file/repository/PathRepository.java
@@ -1,19 +1,19 @@
 package com.ogjg.back.file.repository;
 
-import com.ogjg.back.file.domain.File;
+import com.ogjg.back.file.domain.Path;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface FileRepository extends JpaRepository<File, String> {
+public interface PathRepository extends JpaRepository<Path, String> {
 
     @Query("""
-    select f.uuid from File f join f.container c on f.container.containerId = c.containerId
+    select p.uuid from Path p join p.container c on p.container.containerId = c.containerId
     where c.containerId = :containerId
-    and f.path = :key
-    and f.name = :filename
+    and p.path = :key
+    and p.name = :filename
 """)
     Optional<String> findUuid(@Param("containerId") Long containerId, @Param("key") String key, @Param("filename") String filename);
 }

--- a/back/src/test/java/com/ogjg/back/common/ControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/common/ControllerTest.java
@@ -3,6 +3,7 @@ package com.ogjg.back.common;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ogjg.back.config.security.jwt.JwtUserDetails;
 import com.ogjg.back.container.controller.ContainerController;
+import com.ogjg.back.container.controller.MainController;
 import com.ogjg.back.container.service.ContainerService;
 import com.ogjg.back.directory.controller.DirectoryController;
 import com.ogjg.back.directory.service.DirectoryService;
@@ -36,7 +37,8 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
         UserController.class,
         ContainerController.class,
         FileController.class,
-        DirectoryController.class
+        DirectoryController.class,
+        MainController.class
 })
 public class ControllerTest {
 

--- a/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
@@ -2,6 +2,7 @@ package com.ogjg.back.container.controller;
 
 import com.ogjg.back.common.ControllerTest;
 import com.ogjg.back.container.dto.request.ContainerCreateRequest;
+import com.ogjg.back.container.dto.request.ContainerGetDirectoryResponse;
 import com.ogjg.back.container.dto.response.ContainerGetFileResponse;
 import com.ogjg.back.container.dto.response.ContainerCheckNameResponse;
 import com.ogjg.back.container.dto.response.ContainerGetNodeResponse;
@@ -134,7 +135,7 @@ public class ContainerControllerTest extends ControllerTest {
                 "/containerName/h1/h2/hello11.txt", "/containerName/h1/h3/hello13.txt"
         );
 
-        List<String> directories = List.of("/containerName/",
+        List<String> directoryList = List.of("/containerName/",
                 "/containerName/h1/", "/containerName/h2/",
                 "/containerName/h3/", "/containerName/h4/",
                 "/containerName/h1/h2/", "/containerName/h1/h3/"
@@ -142,7 +143,14 @@ public class ContainerControllerTest extends ControllerTest {
 
         List<String> parsedKeys = new ArrayList<>();
         parsedKeys.addAll(fileKeys);
-        parsedKeys.addAll(directories);
+        parsedKeys.addAll(directoryList);
+
+        List<ContainerGetDirectoryResponse> directories = directoryList.stream()
+                .map((key) -> ContainerGetDirectoryResponse.builder()
+                        .directory(key)
+                        .uuid("uuid")
+                        .build())
+                .toList();
 
         ContainerGetNodeResponse treeData = ContainerGetNodeResponse.buildTreeFromKeys(parsedKeys);
         List<ContainerGetFileResponse> fileData = fileKeys.stream()
@@ -197,7 +205,8 @@ public class ContainerControllerTest extends ControllerTest {
                                 fieldWithPath("data.fileData[].filePath").description("파일 경로"),
                                 fieldWithPath("data.fileData[].content").description("파일 내용"),
                                 fieldWithPath("data.fileData[].uuid").description("파일 uuid"),
-                                fieldWithPath("data.directories").description("모든 디렉토리 경로")
+                                fieldWithPath("data.directories[].directory").description("모든 디렉토리 경로"),
+                                fieldWithPath("data.directories[].uuid").description("모든 디렉토리 경로")
                         )
                 )
         ).andExpect(status().isOk());

--- a/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
@@ -61,37 +61,6 @@ public class ContainerControllerTest extends ControllerTest {
         )).andExpect(status().isOk());
      }
 
-    @DisplayName("컨테이너 삭제")
-    @Test
-    public void deleteContainer() throws Exception {
-        //given
-        ContainerCreateRequest request = ContainerCreateRequest.builder()
-                .name("이회장")
-                .description("자바 연습 할거야")
-                .isPrivate(false)
-                .language("Java")
-                .build();
-
-        doNothing()
-                .when(containerService)
-                .deleteContainer(anyLong(), anyString());
-
-        // when
-        ResultActions result = this.mockMvc.perform(
-                delete("/api/containers/{containerId}", 1L)
-                        .accept(MediaType.APPLICATION_JSON)
-        );
-
-        // then
-        result.andDo(document("container/delete",
-                preprocessRequest(prettyPrint()),
-                preprocessResponse(prettyPrint()),
-                pathParameters(
-                        parameterWithName("containerId").description("컨테이너 ID")
-                )
-        )).andExpect(status().isOk());
-    }
-
     @DisplayName("컨테이너 이름 중복 체크")
     @Test
     public void checkDuplication() throws Exception {

--- a/back/src/test/java/com/ogjg/back/container/controller/MainControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/container/controller/MainControllerTest.java
@@ -1,0 +1,53 @@
+package com.ogjg.back.container.controller;
+
+import com.ogjg.back.common.ControllerTest;
+import com.ogjg.back.container.dto.request.ContainerCreateRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class MainControllerTest extends ControllerTest {
+
+    @DisplayName("컨테이너 삭제")
+    @Test
+    public void deleteContainer() throws Exception {
+        //given
+        ContainerCreateRequest request = ContainerCreateRequest.builder()
+                .name("이회장")
+                .description("자바 연습 할거야")
+                .isPrivate(false)
+                .language("Java")
+                .build();
+
+        doNothing()
+                .when(containerService)
+                .deleteContainer(anyLong(), anyString());
+
+        // when
+        ResultActions result = this.mockMvc.perform(
+                delete("/api/main/containers/{containerId}", 1L)
+                        .accept(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        result.andDo(document("container/delete",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("containerId").description("컨테이너 ID")
+                )
+        )).andExpect(status().isOk());
+    }
+}

--- a/back/src/test/java/com/ogjg/back/container/service/ContainerServiceTest.java
+++ b/back/src/test/java/com/ogjg/back/container/service/ContainerServiceTest.java
@@ -5,6 +5,8 @@ import com.ogjg.back.container.dto.request.ContainerCreateRequest;
 import com.ogjg.back.container.dto.response.ContainerCheckNameResponse;
 import com.ogjg.back.container.exception.DuplicatedContainerName;
 import com.ogjg.back.container.repository.ContainerRepository;
+import com.ogjg.back.directory.repository.DirectoryRepository;
+import com.ogjg.back.file.domain.Path;
 import com.ogjg.back.s3.service.S3ContainerService;
 import com.ogjg.back.user.domain.User;
 import com.ogjg.back.user.domain.UserStatus;
@@ -37,7 +39,10 @@ public class ContainerServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private S3ContainerService s3ContainerService;
+    S3ContainerService s3ContainerService;
+
+    @Mock
+    private DirectoryRepository directoryRepository;
 
     private User user;
 
@@ -67,14 +72,22 @@ public class ContainerServiceTest {
         given(userRepository.findByEmail(loginEmail))
                 .willReturn(Optional.of(user));
 
+        given(s3ContainerService.createContainer(anyString()))
+                .willReturn("directory");
+
         given(containerRepository.findByNameAndEmail(request.getName(), loginEmail))
                 .willReturn(Optional.empty());
+
+        given(directoryRepository.save(any(Path.class)))
+                .willReturn(Path.builder().build());
 
         // when
         containerService.createContainer(loginEmail, request);
 
         // then
         then(containerRepository).should().save(any(Container.class));
+        then(directoryRepository).should().save(any(Path.class));
+
     }
 
     @DisplayName("컨테이너 생성 예외 - 유저가 존재하지 않는 경우")

--- a/back/src/test/java/com/ogjg/back/file/controller/PathControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/file/controller/PathControllerTest.java
@@ -18,7 +18,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class FileControllerTest extends ControllerTest {
+public class PathControllerTest extends ControllerTest {
 
     @DisplayName("파일 생성")
     @Test


### PR DESCRIPTION
### Feat : OW-98 디렉토리 api에 uuid 관련 db 로직 추가
- [x] File 엔티티 이름 Path로 변경
  - 기존에 임시로 File의 경로만 저장했지만, 디렉토리 경로도 함께 저장하는 것으로 변경했다.
- [x] 생성, 삭제, 이름 수정 기능에 uuid 추가
  - 생성 시 Path 엔티티  db에 저장
  - 삭제 시 Path도 같이 삭제
  - 이름 수정 시 db에 해당 이름을 찾아 rename
- [x] 파일 이름이 중복되는 버그 수정
  - 파일/디렉토리 rename 기능에서 이름을 수정할 경로를 찾을 때, 이름을 제외하고 prefix 경로로만 검색을 해서 오류가 발생
  - path와 name 둘 다 사용해서 정확한 검색을 하도록 수정했다.
- [x] S3PathUtil에 불필요한 중복 메서드 extractKeyPrefix 제거

### Feat : OW-99 컨테이너 구조 불러오기 응답 데이터 수정
- [x] directories를 응답List로 변경
- [x] 응답 값에 uuid 추가
- [x] ContainerControllerTest 수정

### Test : 컨테이너 삭제 테스트 ConatinerControllerTest에서 MainControllerTest로 이전
###  Feat : OW-98 디렉토리 api db 로직 수정
- [x] 컨테이너 생성 시 루트 경로 db에 반영
- [x] 디렉토리 api db 관련 로직 수정
  - 상위 디렉토리 삭제 시 하위 항목 같이 삭제
  - 상위 디렉토리 이름 수정 시 하위 항목 같이 수정
- [x] ContainerServiceTest 수정