### PR TITLE
Feat : OW-102 BE 컨테이너 공유를 위해 토큰의 email을 사용하지 않도록 API 수정

### DIFF
--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -126,6 +126,7 @@ include::{snippets}/file/rename/http-response.adoc[]
 해당 경로의 파일을 생성합니다.
 
 include::{snippets}/directory/create/http-request.adoc[]
+include::{snippets}/directory/create/path-parameters.adoc[]
 include::{snippets}/directory/create/query-parameters.adoc[]
 include::{snippets}/directory/create/request-body.adoc[]
 include::{snippets}/directory/create/request-fields.adoc[]
@@ -136,6 +137,7 @@ include::{snippets}/directory/create/http-response.adoc[]
 해당 경로의 파일을 생성합니다.
 
 include::{snippets}/directory/delete/http-request.adoc[]
+include::{snippets}/directory/delete/path-parameters.adoc[]
 include::{snippets}/directory/delete/query-parameters.adoc[]
 
 include::{snippets}/directory/delete/http-response.adoc[]
@@ -144,6 +146,7 @@ include::{snippets}/directory/delete/http-response.adoc[]
 해당 경로의 파일을 생성합니다.
 
 include::{snippets}/directory/rename/http-request.adoc[]
+include::{snippets}/directory/rename/path-parameters.adoc[]
 include::{snippets}/directory/rename/query-parameters.adoc[]
 
 include::{snippets}/directory/rename/http-response.adoc[]

--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -88,6 +88,7 @@ include::{snippets}/container/get/http-response.adoc[]
 해당 경로의 파일을 생성합니다.
 
 include::{snippets}/file/create/http-request.adoc[]
+include::{snippets}/file/create/path-parameters.adoc[]
 include::{snippets}/file/create/query-parameters.adoc[]
 include::{snippets}/file/create/request-body.adoc[]
 include::{snippets}/file/create/request-fields.adoc[]
@@ -98,6 +99,7 @@ include::{snippets}/file/create/http-response.adoc[]
 해당 경로의 파일을 삭제합니다.
 
 include::{snippets}/file/delete/http-request.adoc[]
+include::{snippets}/file/delete/path-parameters.adoc[]
 include::{snippets}/file/delete/query-parameters.adoc[]
 
 include::{snippets}/file/delete/http-response.adoc[]
@@ -106,6 +108,7 @@ include::{snippets}/file/delete/http-response.adoc[]
 해당 경로의 파일을 수정합니다.
 
 include::{snippets}/file/update/http-request.adoc[]
+include::{snippets}/file/update/path-parameters.adoc[]
 include::{snippets}/file/update/query-parameters.adoc[]
 include::{snippets}/file/update/request-body.adoc[]
 include::{snippets}/file/update/request-fields.adoc[]
@@ -116,6 +119,7 @@ include::{snippets}/file/update/http-response.adoc[]
 해당 경로의 파일의 이름을 수정합니다.
 
 include::{snippets}/file/rename/http-request.adoc[]
+include::{snippets}/file/rename/path-parameters.adoc[]
 include::{snippets}/file/rename/query-parameters.adoc[]
 
 include::{snippets}/file/rename/http-response.adoc[]

--- a/back/src/docs/asciidoc/index.adoc
+++ b/back/src/docs/asciidoc/index.adoc
@@ -80,7 +80,7 @@ include::{snippets}/container/get/path-parameters.adoc[]
 
 include::{snippets}/container/get/http-response.adoc[]
 include::{snippets}/container/get/response-fields.adoc[]
-include::{snippets}/container/check/http-response.adoc[]
+include::{snippets}/container/get/http-response.adoc[]
 
 == 파일 API
 

--- a/back/src/main/java/com/ogjg/back/container/controller/ContainerController.java
+++ b/back/src/main/java/com/ogjg/back/container/controller/ContainerController.java
@@ -54,7 +54,7 @@ public class ContainerController {
     ) {
         return new ApiResponse<>(
                 ErrorCode.SUCCESS,
-                containerService.getAllFilesAndDirectories(containerId, user.getEmail())
+                containerService.getAllFilesAndDirectories(containerId)
         );
     }
 }

--- a/back/src/main/java/com/ogjg/back/directory/controller/DirectoryController.java
+++ b/back/src/main/java/com/ogjg/back/directory/controller/DirectoryController.java
@@ -2,18 +2,16 @@ package com.ogjg.back.directory.controller;
 
 import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.response.ApiResponse;
-import com.ogjg.back.config.security.jwt.JwtUserDetails;
 import com.ogjg.back.directory.dto.request.CreateDirectoryRequest;
 import com.ogjg.back.directory.service.DirectoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/directories")
+@RequestMapping("/api/containers/{containerId}/directories")
 public class DirectoryController {
 
     private final DirectoryService directoryService;
@@ -23,11 +21,11 @@ public class DirectoryController {
      */
     @PostMapping("")
     public ApiResponse<Void> creatDirectory(
+            @PathVariable("containerId") Long containerId,
             @RequestParam("directoryPath") String directoryPath,
-            @RequestBody CreateDirectoryRequest request,
-            @AuthenticationPrincipal JwtUserDetails user
+            @RequestBody CreateDirectoryRequest request
     ) {
-        directoryService.createDirectory(user.getEmail(), directoryPath, request);
+        directoryService.createDirectory(containerId, directoryPath, request);
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 
@@ -36,10 +34,10 @@ public class DirectoryController {
      */
     @DeleteMapping("")
     public ApiResponse<Void> deleteDirectory(
-            @RequestParam String directoryPath,
-            @AuthenticationPrincipal JwtUserDetails user
+            @PathVariable("containerId") Long containerId,
+            @RequestParam("directoryPath") String directoryPath
     ) {
-        directoryService.deleteDirectory(user.getEmail(), directoryPath);
+        directoryService.deleteDirectory(containerId, directoryPath);
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 
@@ -48,11 +46,11 @@ public class DirectoryController {
      */
     @PutMapping("/rename")
     public ApiResponse<Void> updateFilename(
-            @RequestParam String directoryPath,
-            @RequestParam String newDirectoryName,
-            @AuthenticationPrincipal JwtUserDetails user
+            @PathVariable("containerId") Long containerId,
+            @RequestParam("directoryPath") String directoryPath,
+            @RequestParam("newDirectoryName") String newDirectoryName
     ) {
-        directoryService.updateDirectoryName(user.getEmail(), directoryPath, newDirectoryName);
+        directoryService.updateDirectoryName(containerId, directoryPath, newDirectoryName);
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 }

--- a/back/src/main/java/com/ogjg/back/file/controller/FileController.java
+++ b/back/src/main/java/com/ogjg/back/file/controller/FileController.java
@@ -2,19 +2,17 @@ package com.ogjg.back.file.controller;
 
 import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.response.ApiResponse;
-import com.ogjg.back.config.security.jwt.JwtUserDetails;
 import com.ogjg.back.file.dto.request.CreateFileRequest;
 import com.ogjg.back.file.dto.request.UpdateFileRequest;
 import com.ogjg.back.file.service.FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/api/files")
+@RequestMapping("/api/containers/{containerId}/files")
 public class FileController {
 
     private final FileService fileService;
@@ -24,11 +22,11 @@ public class FileController {
      */
     @PostMapping("")
     public ApiResponse<Void> createFile(
+            @PathVariable("containerId") Long containerId,
             @RequestParam("filePath") String filePath,
-            @RequestBody CreateFileRequest request,
-            @AuthenticationPrincipal JwtUserDetails user
+            @RequestBody CreateFileRequest request
     ) {
-        fileService.createFile(user.getEmail(), filePath, request.getUuid());
+        fileService.createFile(containerId, filePath, request.getUuid());
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 
@@ -37,10 +35,11 @@ public class FileController {
      */
     @DeleteMapping("")
     public ApiResponse<Void> deleteFile(
-        @RequestParam("filePath") String filePath,
-            @AuthenticationPrincipal JwtUserDetails user
+            @PathVariable("containerId") Long containerId,
+            @RequestParam("filePath") String filePath
     ) {
-        fileService.deleteFile(user.getEmail(), filePath);
+
+        fileService.deleteFile(containerId, filePath);
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 
@@ -49,11 +48,11 @@ public class FileController {
      */
     @PutMapping("")
     public ApiResponse<Void> updateFile(
+            @PathVariable("containerId") Long containerId,
             @RequestParam("filePath") String filePath,
-            @RequestBody UpdateFileRequest request,
-            @AuthenticationPrincipal JwtUserDetails user
+            @RequestBody UpdateFileRequest request
     ) {
-        fileService.updateFile(user.getEmail(), filePath, request);
+        fileService.updateFile(containerId, filePath, request);
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 
@@ -62,12 +61,11 @@ public class FileController {
      */
     @PutMapping("/rename")
     public ApiResponse<Void> updateFilename(
+            @PathVariable("containerId") Long containerId,
             @RequestParam String filePath,
-            @RequestParam String newFilename,
-            @AuthenticationPrincipal JwtUserDetails user
-
+            @RequestParam String newFilename
     ) {
-        fileService.updateFilename(user.getEmail(), filePath, newFilename);
+        fileService.updateFilename(containerId, filePath, newFilename);
         return new ApiResponse<>(ErrorCode.SUCCESS);
     }
 }

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
@@ -70,15 +70,15 @@ public class S3FileRepository {
         }
     }
 
-    public void rename(String s3Path, String newFilePath) {
+    public void rename(String s3Path, String newS3FilePath) {
         log.info("nowFilePath={}", s3Path);
-        log.info("newFilePath={}", newFilePath);
+        log.info("newS3FilePath={}", newS3FilePath);
         try {
             CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder()
                     .sourceBucket(bucketName)
                     .sourceKey(s3Path)
                     .destinationBucket(bucketName)
-                    .destinationKey(newFilePath)
+                    .destinationKey(newS3FilePath)
                     .build();
 
             s3Client.copyObject(copyObjectRequest);

--- a/back/src/main/java/com/ogjg/back/s3/service/S3DirectoryService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3DirectoryService.java
@@ -8,8 +8,6 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.util.List;
 
-import static com.ogjg.back.common.util.S3PathUtil.givenPathToS3Path;
-
 @Service
 @RequiredArgsConstructor
 public class S3DirectoryService {
@@ -17,10 +15,8 @@ public class S3DirectoryService {
     private final S3DirectoryRepository s3DirectoryRepository;
 
     @Transactional
-    public void createDirectory(String email, String directoryPath) {
-        s3DirectoryRepository.putDirectoryPath(
-                givenPathToS3Path(email, directoryPath)
-        );
+    public void createDirectory(String s3Path) {
+        s3DirectoryRepository.putDirectoryPath(s3Path);
     }
 
     @Transactional(readOnly = true)
@@ -29,10 +25,8 @@ public class S3DirectoryService {
     }
 
     @Transactional
-    public void deleteDirectory(String email, String directoryPath) {
-        s3DirectoryRepository.deleteObjectsWithPrefix(
-                givenPathToS3Path(email, directoryPath)
-        );
+    public void deleteDirectory(String s3Path) {
+        s3DirectoryRepository.deleteObjectsWithPrefix(s3Path);
     }
 
     @Transactional

--- a/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3FileService.java
@@ -14,22 +14,18 @@ public class S3FileService {
     private final S3FileRepository s3FileRepository;
 
     @Transactional
-    public void createFile(String email, String filePath) {
-        s3FileRepository.putFilePath(
-                givenPathToS3Path(email, filePath)
-        );
+    public void createFile(String s3Path) {
+        s3FileRepository.putFilePath(s3Path);
     }
 
     @Transactional
-    public void deleteFile(String email, String filePath) {
-        s3FileRepository.deleteFile(
-                givenPathToS3Path(email, filePath)
-        );
+    public void deleteFile(String s3Path) {
+        s3FileRepository.deleteFile(s3Path);
     }
     @Transactional
-    public void updateFile(String email, String filePath, String content) {
+    public void updateFile(String s3Path, String content) {
         s3FileRepository.putFile(
-                givenPathToS3Path(email, filePath),
+                s3Path,
                 content
         );
     }

--- a/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
@@ -137,7 +137,7 @@ public class ContainerControllerTest extends ControllerTest {
                 .directories(directories)
                 .build();
 
-        given(containerService.getAllFilesAndDirectories(anyLong(), anyString()))
+        given(containerService.getAllFilesAndDirectories(anyLong()))
                 .willReturn(response);
 
         //when

--- a/back/src/test/java/com/ogjg/back/directory/controller/DirectoryControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/directory/controller/DirectoryControllerTest.java
@@ -7,17 +7,20 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.any;
 import static org.mockito.BDDMockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class DirectoryControllerTest extends ControllerTest {
+
+    public static final String PREFIX = "/api/containers/{containerId}/directories";
 
     @DisplayName("디렉토리 생성 - 해당 컨테이너가 존재하고, 해당 경로가 존재하지 않는다면 디렉토리를 생성한다.")
     @Test
@@ -27,11 +30,11 @@ public class DirectoryControllerTest extends ControllerTest {
                 .uuid("uuid")
                 .build();
 
-        doNothing().when(directoryService).createDirectory(any(String.class), any(String.class), any(CreateDirectoryRequest.class));
+        doNothing().when(directoryService).createDirectory(anyLong(), anyString(), any(CreateDirectoryRequest.class));
 
         //when
         ResultActions result = this.mockMvc.perform(
-                post("/api/directories")
+                post(PREFIX, 1L)
                         .queryParam("directoryPath", "{directoryPath}")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -42,6 +45,9 @@ public class DirectoryControllerTest extends ControllerTest {
         result.andDo(document("directory/create",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                pathParameters(
+                  parameterWithName("containerId").description("수정할 컨테이너의 ID")
+                ),
                 queryParameters(
                         parameterWithName("directoryPath").description("생성할 디렉토리 전체 경로")
                 ),
@@ -60,11 +66,11 @@ public class DirectoryControllerTest extends ControllerTest {
     @Test
     public void deleteDirectory() throws Exception {
         //given
-        doNothing().when(directoryService).deleteDirectory(any(String.class), any(String.class));
+        doNothing().when(directoryService).deleteDirectory(anyLong(), anyString());
 
         //when
         ResultActions result = this.mockMvc.perform(
-                delete("/api/directories")
+                delete(PREFIX, 1L)
                         .queryParam("directoryPath", "{directoryPath}")
                         .accept(MediaType.APPLICATION_JSON)
         );
@@ -73,6 +79,9 @@ public class DirectoryControllerTest extends ControllerTest {
         result.andDo(document("directory/delete",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("containerId").description("수정할 컨테이너의 ID")
+                ),
                 queryParameters(
                         parameterWithName("directoryPath").description("삭제할 디렉토리 전체 경로")
                 ),
@@ -88,11 +97,11 @@ public class DirectoryControllerTest extends ControllerTest {
     @Test
     public void updateDirectoryName() throws Exception {
         //given
-        doNothing().when(directoryService).updateDirectoryName(any(String.class), any(String.class), any(String.class));
+        doNothing().when(directoryService).updateDirectoryName(anyLong(), anyString(), anyString());
 
         //when
         ResultActions result = this.mockMvc.perform(
-                put("/api/directories/rename")
+                put(PREFIX + "/rename", 1L)
                         .queryParam("directoryPath", "{directoryPath}")
                         .queryParam("newDirectoryName", "{newDirectoryName}")
                         .accept(MediaType.APPLICATION_JSON)
@@ -102,6 +111,9 @@ public class DirectoryControllerTest extends ControllerTest {
         result.andDo(document("directory/rename",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("containerId").description("수정할 컨테이너의 ID")
+                ),
                 queryParameters(
                         parameterWithName("directoryPath").description("수정할 디렉토리의 기존 전체 경로"),
                         parameterWithName("newDirectoryName").description("새로 지은 디렉토리의 이름")

--- a/back/src/test/java/com/ogjg/back/file/controller/FileControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/file/controller/FileControllerTest.java
@@ -8,17 +8,19 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-public class PathControllerTest extends ControllerTest {
+public class FileControllerTest extends ControllerTest {
+
+
+    public static final String PREFIX = "/api/containers/{containerId}/files";
 
     @DisplayName("파일 생성")
     @Test
@@ -28,11 +30,11 @@ public class PathControllerTest extends ControllerTest {
                 .uuid("uuid")
                 .build();
 
-        doNothing().when(fileService).createFile(any(String.class), any(String.class), any(String.class));
+        doNothing().when(fileService).createFile(anyLong(), anyString(), anyString());
 
         //when
         ResultActions result = this.mockMvc.perform(
-                post("/api/files")
+                post(PREFIX, 1L)
                         .queryParam("filePath", "{filePath}")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -43,6 +45,9 @@ public class PathControllerTest extends ControllerTest {
         result.andDo(document("file/create",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("containerId").description("컨테이너 ID")
+                ),
                 queryParameters(
                         parameterWithName("filePath").description("생성할 파일 전체 경로")
                 ),
@@ -61,11 +66,11 @@ public class PathControllerTest extends ControllerTest {
     @Test
     public void deleteFile() throws Exception {
         //given
-        doNothing().when(fileService).deleteFile(any(String.class), any(String.class));
+        doNothing().when(fileService).deleteFile(anyLong(), anyString());
 
         //when
         ResultActions result = this.mockMvc.perform(
-                delete("/api/files")
+                delete(PREFIX, 1L)
                         .queryParam("filePath", "{filePath}")
                         .accept(MediaType.APPLICATION_JSON)
         );
@@ -74,6 +79,9 @@ public class PathControllerTest extends ControllerTest {
         result.andDo(document("file/delete",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("containerId").description("컨테이너 ID")
+                ),
                 queryParameters(
                         parameterWithName("filePath").description("삭제할 파일 전체 경로")
                 ),
@@ -94,11 +102,11 @@ public class PathControllerTest extends ControllerTest {
                         "do you know?")
                 .build();
 
-        doNothing().when(fileService).updateFile(any(String.class), any(String.class), any(UpdateFileRequest.class));
+        doNothing().when(fileService).updateFile(anyLong(), anyString(), any(UpdateFileRequest.class));
 
         //when
         ResultActions result = this.mockMvc.perform(
-                put("/api/files")
+                put(PREFIX, 1L)
                         .queryParam("filePath", "{filePath}")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
@@ -109,6 +117,9 @@ public class PathControllerTest extends ControllerTest {
         result.andDo(document("file/update",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("containerId").description("컨테이너 ID")
+                ),
                 queryParameters(
                         parameterWithName("filePath").description("수정할 파일의 전체 경로")
                 ),
@@ -127,11 +138,11 @@ public class PathControllerTest extends ControllerTest {
     @Test
     public void updateFilename() throws Exception {
         //given
-        doNothing().when(fileService).updateFilename(any(String.class), any(String.class), any(String.class));
+        doNothing().when(fileService).updateFilename(anyLong(), anyString(), anyString());
 
         //when
         ResultActions result = this.mockMvc.perform(
-                put("/api/files/rename")
+                put(PREFIX + "/rename", 1L)
                         .queryParam("filePath","{filePath}")
                         .queryParam("newFilename", "{newFilename}")
                         .accept(MediaType.APPLICATION_JSON)
@@ -141,6 +152,9 @@ public class PathControllerTest extends ControllerTest {
         result.andDo(document("file/rename",
                 preprocessRequest(prettyPrint()),
                 preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("containerId").description("컨테이너 ID")
+                ),
                 queryParameters(
                         parameterWithName("filePath").description("수정할 파일의 전체 경로"),
                         parameterWithName("newFilename").description("새로 지정할 파일 이름")


### PR DESCRIPTION
- 기본적으로 토큰에서 이메일을 가져와서 s3 경로 조회에 사용 때문에 본인의 컨테이너 밖에 접근할 수 없다.
- 컨테이너 공유 기능을 위해 우선 다른 사람이 접근 가능하도록 containerId를 경로변수로 받아서 해당 컨테이너의 email을 조회하도록 수정

### Feat : OW-102 컨테이너 모든 구조 내려주기 containerId로 이메일 조회하도록 변경
- [x] 토큰의 이메일이 아닌 해당 컨테이너의 이메일로 컨테이너 정보를 찾아오도록 수정
- [x] ContainerController 테스트 수정, anyString(), anyLong() 사용
- [x] adoc 갱신 및 오타 수정

### Feat : OW-102 디렉토리 관련 API 토큰 이메일 제거 및 containerId 추가

- [x] 토큰 이메일 제거 및 containerId 추가
- [x] 요청 매핑에 경로 변경,  경로변수로 containerId 추가
- [x] 중복되는 s3Path 생성 로직 제거
- [x] DirectoryControllerTest 수정
  - url에 PREFIX 추가
  - anyString(), anyLong()으로 변경
- [x] adoc 갱신

### Feat : OW-102 파일 관련 API 토큰 이메일 제거 및 containerId 추가
- [x]  토큰 이메일 제거 및 containerId 추가
- [x] 요청 매핑에 경로 변경,  경로변수로 containerId 추가
- [x] 중복되는 s3Path 생성 로직 제거
- [x] FileControllerTest 수정
  - 잘못된 클래스 이름 수정 (PathControllerTest -> FileControllerTest)
  - url에 PREFIX 추가
  - anyString(), anyLong()으로 변경
- [x] adoc 갱신