### PR TITLE
Fix : OW-104 폴더 삭제 시 폴더 내부에 있는 파일 탭 안닫히는 버그

### DIFF
--- a/front/src/api/useFilesAPI.ts
+++ b/front/src/api/useFilesAPI.ts
@@ -13,6 +13,7 @@ export function useFilesAPI() {
     renameFile,
     renameDirectory,
     deleteFile,
+    deleteDirectory,
     saveFile,
     saveActiveTabFile,
   } = useFileManage();
@@ -120,7 +121,7 @@ export function useFilesAPI() {
         `${import.meta.env.VITE_API_URL}/api/directories?directoryPath=${directoryPath}`,
       )
       .then(() => {
-        deleteFile(info);
+        deleteDirectory(info);
       })
       .catch((error) => {
         console.log(error);


### PR DESCRIPTION
- 폴더 삭제 시 탭 상태에서 관련 파일 탭 닫는 로직 추가
- 활성화 탭 재지정 로직 추가
  - 닫힌 탭 중 가장 앞의 탭의 전 탭을 활성화 탭으로 지정
  - 모든 탭이 닫힌 경우 코드 에디터 컴포넌트 비렌더링