### PR TITLE
Fix : OW-109 이미지 url 버그 수정

### DIFF
--- a/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
+++ b/back/src/main/java/com/ogjg/back/common/util/S3PathUtil.java
@@ -5,24 +5,30 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 public class S3PathUtil {
 
     public static final String DELIMITER = "/";
-    public static final char S3_EMAIL_DELIMETER = '-';
+    public static final char S3_EMAIL_DELIMITER = '-';
+    public static final String EXTENSION_DOT = ".";
 
-    /**
-     * email을 s3 prefix로 사용하기 위해 특수문자를 '-'로 대체한다.
-     */
     public static String createContainerPrefix(String loginEmail, String containerName) {
-        loginEmail = loginEmail
-                .replace('.', S3_EMAIL_DELIMETER)
-                .replace('@', S3_EMAIL_DELIMETER);
-        return (DELIMITER + loginEmail + DELIMITER + containerName + DELIMITER);
+        return (DELIMITER + toS3Email(loginEmail) + DELIMITER + containerName + DELIMITER);
 
     }
 
     public static String givenPathToS3Path(String loginEmail, String filePath) {
-        loginEmail = loginEmail
-                .replace('.', S3_EMAIL_DELIMETER)
-                .replace('@', S3_EMAIL_DELIMETER);
-        return (DELIMITER + loginEmail + filePath);
+        return (DELIMITER + toS3Email(loginEmail) + filePath);
+    }
+
+    public static String createImagePrefix(String email) {
+        return DELIMITER + toS3Email(email) + DELIMITER + "image.";
+    }
+
+    /**
+     * email을 s3 prefix로 사용하기 위해 특수문자를 '-'로 대체한다.
+     */
+    private static String toS3Email(String email) {
+        String S3Email = email
+                .replace('.', S3_EMAIL_DELIMITER)
+                .replace('@', S3_EMAIL_DELIMITER);
+        return S3Email;
     }
 
     /**
@@ -39,7 +45,7 @@ public class S3PathUtil {
     }
 
     public static boolean isFile(String path) {
-        return path.contains(".");
+        return path.contains(EXTENSION_DOT);
     }
 
     public static String createNewFilePath(String originPath, String newFilename) {
@@ -76,12 +82,8 @@ public class S3PathUtil {
         return directoryPath.substring(secondLastDelimiterIndex + 1);
     }
 
-    public static String createImagePrefix(String email) {
-        return DELIMITER + email + DELIMITER + "image.";
-    }
-
     public static String extractExtension(String originalName) {
-        int index = originalName.lastIndexOf('.');
+        int index = originalName.lastIndexOf(EXTENSION_DOT);
         return originalName.substring(index + 1); // .제외한 확장자만 추출한다.
     }
 

--- a/back/src/main/java/com/ogjg/back/s3/service/S3ProfileImageService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3ProfileImageService.java
@@ -29,9 +29,9 @@ public class S3ProfileImageService {
 
         s3ImageUploadRepository.deleteObjectsWithPrefix(prefix);
 
-        String fileName = prefix + extractExtension(originalName);
-
-        return s3ImageUploadRepository.uploadFile(multipartFile, fileName)
+        String filePath = prefix + extractExtension(originalName);
+        log.info("fileName={}",filePath);
+        return s3ImageUploadRepository.uploadFile(multipartFile, filePath)
                 .orElseThrow(() -> new S3ImageUploadException());
     }
 }


### PR DESCRIPTION
### 문제 상황
- 구분자 오류
  - aws java sdk를 통해 받아오는 url에는 이메일 앞에 구분자가 1개인데, 
  - 생성된 key의 url에는 이메일 앞에 구분자가 2개인 상황
  - 결과적으로 sdk에서 받아온 url을 가지고 있다가 사용자에게 전달해주니, 생성된 key와 주소가 달라서 이미지를 볼 수 없었다.

### 잘못된 이미지 경로
- s3에 각 사용자의 루트 경로가 아닌 잘못된 다른 경로가 생기면서 이미지가 저장되는 버그 발생
  - 이미지 경로에 이메일이 `email-naver-com` 과 같은 형식으로 수정되어 들어가야하는데 `email@naver.com` 과 같이 원본 경로로 저장되도록 잘못 구현해서 발생했다.

### Fix : OW-109 이미지 url 버그 수정
- [x] aws java sdk로 받아온 url과 key값의 url이 불일치하는 버그 수정
- 경로 전체를 수정하기엔 소요가 커서 url을 받아오지 않고 직접 생성해서 해결
- [x] s3 경로에 이메일이 그대로 들어가는 오류 수정
- 이미지 저장 로직에 이메일 변환 로직 추가