### PR TITLE
Refactor : OW-83 BE 파일/디렉토리 API 리팩터링

### DIFF
--- a/back/src/main/java/com/ogjg/back/common/util/PathUtil.java
+++ b/back/src/main/java/com/ogjg/back/common/util/PathUtil.java
@@ -1,51 +1,36 @@
 package com.ogjg.back.common.util;
 
-import software.amazon.awssdk.services.s3.model.S3Object;
-
-public class S3PathUtil {
-
+public class PathUtil {
     public static final String DELIMITER = "/";
-    public static final char S3_EMAIL_DELIMITER = '-';
-    public static final String EXTENSION_DOT = ".";
-
-    public static String createContainerPrefix(String loginEmail, String containerName) {
-        return (DELIMITER + toS3Email(loginEmail) + DELIMITER + containerName + DELIMITER);
-
-    }
-
-    public static String givenPathToS3Path(String loginEmail, String filePath) {
-        return (DELIMITER + toS3Email(loginEmail) + filePath);
-    }
+    public static final String S3_URL_DELIMITER = "-";
+    public static final String EXTENSION_SEPARATOR = ".";
+    public static final String PROFILE_IMAGE_FIXED_NAME = "image";
 
     public static String createImagePrefix(String email) {
-        return DELIMITER + toS3Email(email) + DELIMITER + "image.";
+        return DELIMITER + email + DELIMITER + PROFILE_IMAGE_FIXED_NAME + EXTENSION_SEPARATOR;
+    }
+
+    public static String pathToS3Key(String loginEmail, String filePath) {
+        loginEmail = loginEmail
+                .replace(".", S3_URL_DELIMITER)
+                .replace("@", S3_URL_DELIMITER);
+        return (DELIMITER + loginEmail + filePath);
+    }
+
+    public static String createContainerPrefix(String loginEmail, String containerName) {
+        loginEmail = loginEmail
+                .replace(".", S3_URL_DELIMITER)
+                .replace("@", S3_URL_DELIMITER);
+        return (DELIMITER + loginEmail + DELIMITER + containerName + DELIMITER);
     }
 
     /**
-     * email을 s3 prefix로 사용하기 위해 특수문자를 '-'로 대체한다.
-     */
-    private static String toS3Email(String email) {
-        String S3Email = email
-                .replace('.', S3_EMAIL_DELIMITER)
-                .replace('@', S3_EMAIL_DELIMITER);
-        return S3Email;
-    }
-
-    /**
-     * s3 key에서 email 부분을 지운 경로를 반환한다.
+     * s3key에서 email 부분을 지운 경로를 반환한다.
      * - s3에 회원별로 자신의 이메일을 이름으로 하는 루트 디렉토리를 가지고, 그 내부에 컨테이너마다 디렉토리가 생성된다.
      * - 사용자는 주로 컨테이너 단위로 서비스를 이용해서 email을 제거한다.
      */
     public static String createEmailRemovedKey(String key, String email) {
         return key.substring(email.length() + 1); // "/이메일" 을 제외한 디렉토리
-    }
-
-    public static String extractContainerName(String filePath) {
-        return filePath.split(DELIMITER)[1]; // 경로 시작이 / 이므로 배열 첫 요소는 비어있다.
-    }
-
-    public static boolean isFile(String path) {
-        return path.contains(EXTENSION_DOT);
     }
 
     public static String createNewFilePath(String originPath, String newFilename) {
@@ -58,8 +43,8 @@ public class S3PathUtil {
         return originPath.substring(0, secondLastDelimiterIndex) + DELIMITER + newFilename + DELIMITER;
     }
 
-    public static String createNewKey(String originPrefix, String newS3Path, S3Object s3Object) {
-        return newS3Path + s3Object.key().substring(originPrefix.length());
+    public static String createNewKey(String originKey, String originPrefix, String newS3Prefix) {
+        return newS3Prefix + originKey.substring(originPrefix.length());
     }
 
     public static String extractFilename(String filePath) {
@@ -83,10 +68,17 @@ public class S3PathUtil {
     }
 
     public static String extractExtension(String originalName) {
-        int index = originalName.lastIndexOf(EXTENSION_DOT);
+        int index = originalName.lastIndexOf(EXTENSION_SEPARATOR);
         return originalName.substring(index + 1); // .제외한 확장자만 추출한다.
     }
 
+    public static boolean isFile(String path) {
+        return path.contains(EXTENSION_SEPARATOR);
+    }
+
+    /**
+     * 맨뒤 '/' 절삭 후 마지막 '/' 인덱스를 찾으면 뒤에서 두번째 '/'를 찾을 수 있다.
+     */
     private static int findSecondLastDelimiterIndex(String directoryPath) {
         String temp = directoryPath.substring(0, directoryPath.length() - 1);
         return temp.lastIndexOf(DELIMITER);

--- a/back/src/main/java/com/ogjg/back/container/domain/Container.java
+++ b/back/src/main/java/com/ogjg/back/container/domain/Container.java
@@ -107,13 +107,13 @@ public class Container {
         }
     }
 
-    public Path findPath(String filePath, String name) {
+    public Path findPathBy(String prefix, String name) {
         // todo: 1) s3와 구분되는 에러코드 고려하기
         //       2) 쿼리문 활용 최적화 필요
         return paths.stream()
-                .filter((file -> file.getPath().equals(filePath)))
+                .filter((file -> file.getPath().equals(prefix)))
                 .filter((file -> file.getName().equals(name)))
                 .findAny()
-                .orElseThrow(() -> new NotFoundFile("DB에 존재하지 않는 파일입니다."));
+                .orElseThrow(() -> new NotFoundFile("DB에 해당 경로가 존재하지 않습니다."));
     }
 }

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainerGetNodeResponse.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainerGetNodeResponse.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.ogjg.back.common.util.S3PathUtil.isFile;
+import static com.ogjg.back.common.util.PathUtil.isFile;
 import static lombok.AccessLevel.PROTECTED;
 
 @Getter

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainerNodeResponseSerializer.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainerNodeResponseSerializer.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
 
-import static com.ogjg.back.common.util.S3PathUtil.isFile;
+import static com.ogjg.back.common.util.PathUtil.isFile;
 
 public class ContainerNodeResponseSerializer extends JsonSerializer<ContainerGetNodeResponse> {
 

--- a/back/src/main/java/com/ogjg/back/container/service/ContainerService.java
+++ b/back/src/main/java/com/ogjg/back/container/service/ContainerService.java
@@ -14,7 +14,7 @@ import com.ogjg.back.directory.exception.NotFoundDirectory;
 import com.ogjg.back.directory.repository.DirectoryRepository;
 import com.ogjg.back.file.domain.Path;
 import com.ogjg.back.file.exception.NotFoundFile;
-import com.ogjg.back.file.repository.PathRepository;
+import com.ogjg.back.path.repository.PathRepository;
 import com.ogjg.back.s3.repository.S3ContainerRepository;
 import com.ogjg.back.s3.service.S3ContainerService;
 import com.ogjg.back.s3.service.S3DirectoryService;
@@ -29,7 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.UUID;
 
-import static com.ogjg.back.common.util.S3PathUtil.*;
+import static com.ogjg.back.common.util.PathUtil.*;
 
 @Slf4j
 @Service

--- a/back/src/main/java/com/ogjg/back/directory/service/DirectoryService.java
+++ b/back/src/main/java/com/ogjg/back/directory/service/DirectoryService.java
@@ -4,20 +4,12 @@ import com.ogjg.back.container.domain.Container;
 import com.ogjg.back.container.exception.NotFoundContainer;
 import com.ogjg.back.container.repository.ContainerRepository;
 import com.ogjg.back.directory.dto.request.CreateDirectoryRequest;
-import com.ogjg.back.directory.exception.DirectoryAlreadyExists;
-import com.ogjg.back.directory.exception.NotFoundDirectory;
-import com.ogjg.back.directory.repository.DirectoryRepository;
-import com.ogjg.back.file.domain.Path;
-import com.ogjg.back.file.repository.PathRepository;
+import com.ogjg.back.path.service.PathService;
 import com.ogjg.back.s3.service.S3DirectoryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-
-import static com.ogjg.back.common.util.S3PathUtil.*;
 
 @Slf4j
 @Service
@@ -26,47 +18,24 @@ public class DirectoryService {
 
     private final ContainerRepository containerRepository;
     private final S3DirectoryService s3DirectoryService;
-    private final DirectoryRepository directoryRepository;
-    private final PathRepository pathRepository;
+    private final PathService pathService;
 
     @Transactional
     public void createDirectory(Long containerId, String directoryPath, CreateDirectoryRequest request) {
         Container findContainer = findContainerById(containerId);
         String email = findContainer.getUser().getEmail();
-        String s3Path = givenPathToS3Path(email, directoryPath);
 
-//        if (!isContainerExist(email, findContainer.getName())) throw new NotFoundContainer();
-        if (s3DirectoryService.isDirectoryAlreadyExist(s3Path)) throw new DirectoryAlreadyExists();
-
-        directoryRepository.save(Path.builder()
-                .container(findContainer)
-                .path(extractDirectoryPrefix(directoryPath))
-                .name(extractDirectoryName(directoryPath))
-                .uuid(request.getUuid())
-                .build());
-
-        s3DirectoryService.createDirectory(s3Path);
+        pathService.saveDirectoryPath(findContainer, directoryPath, request.getUuid());
+        s3DirectoryService.createDirectory(email, directoryPath);
     }
 
     @Transactional
     public void deleteDirectory(Long containerId, String directoryPath) {
         Container findContainer = findContainerById(containerId);
         String email = findContainer.getUser().getEmail();
-        String s3Path = givenPathToS3Path(email, directoryPath);
 
-        if (!s3DirectoryService.isDirectoryAlreadyExist(s3Path)) throw new NotFoundDirectory();
-
-        // db 삭제
-        pathRepository.findByPathStartsWith(directoryPath).stream()
-                .forEach(pathRepository::delete);
-
-        Path findPath = findContainer.findPath(
-                extractDirectoryPrefix(directoryPath),
-                extractDirectoryName(directoryPath)
-        );
-        pathRepository.delete(findPath);
-
-        s3DirectoryService.deleteDirectory(s3Path);
+        pathService.deleteDirectory(findContainer, directoryPath);
+        s3DirectoryService.deleteDirectory(email, directoryPath);
     }
 
     @Transactional
@@ -74,28 +43,8 @@ public class DirectoryService {
         Container findContainer = findContainerById(containerId);
         String email = findContainer.getUser().getEmail();
 
-        String originS3Path = givenPathToS3Path(email, directoryPath);
-        String newS3Path = createNewDirectoryPath(originS3Path, newDirectoryName);
-
-        if (!s3DirectoryService.isDirectoryAlreadyExist(originS3Path)) throw new NotFoundDirectory();
-
-        // db rename
-        List<Path> changeTargetList = pathRepository.findByPathStartsWith(directoryPath);
-
-        String newAncestorPath = createNewDirectoryPath(directoryPath, newDirectoryName);
-        changeTargetList.stream()
-                .map((path) -> path.renameAncestor(
-                        directoryPath,
-                        newAncestorPath
-                )).toList();
-
-        Path findPath = findContainer.findPath(
-                extractDirectoryPrefix(directoryPath),
-                extractDirectoryName(directoryPath)
-        );
-        findPath.rename(newDirectoryName + DELIMITER);
-
-        s3DirectoryService.updateDirectoryName(originS3Path, newS3Path);
+        pathService.renameDirectory(findContainer, directoryPath, newDirectoryName);
+        s3DirectoryService.updateDirectoryName(email, directoryPath, newDirectoryName);
     }
 
     private Container findContainerById(Long containerId) {

--- a/back/src/main/java/com/ogjg/back/file/domain/Path.java
+++ b/back/src/main/java/com/ogjg/back/file/domain/Path.java
@@ -41,8 +41,8 @@ public class Path {
         return this;
     }
 
-    public Path renameAncestor(String ancestorPath, String newAncestorPath) {
-        this.path = this.path.replace(ancestorPath, newAncestorPath);
+    public Path rename(String directoryPath, String newPrefix) {
+        this.path = (this.path).replace(directoryPath, newPrefix);
         return this;
     }
 }

--- a/back/src/main/java/com/ogjg/back/file/service/FileService.java
+++ b/back/src/main/java/com/ogjg/back/file/service/FileService.java
@@ -1,109 +1,60 @@
 package com.ogjg.back.file.service;
 
-import com.ogjg.back.common.util.S3PathUtil;
 import com.ogjg.back.container.domain.Container;
 import com.ogjg.back.container.exception.NotFoundContainer;
 import com.ogjg.back.container.repository.ContainerRepository;
-import com.ogjg.back.file.domain.Path;
 import com.ogjg.back.file.dto.request.UpdateFileRequest;
-import com.ogjg.back.file.exception.FileAlreadyExists;
-import com.ogjg.back.file.exception.NotFoundFile;
-import com.ogjg.back.file.repository.PathRepository;
+import com.ogjg.back.path.service.PathService;
 import com.ogjg.back.s3.service.S3FileService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static com.ogjg.back.common.util.S3PathUtil.*;
+import static com.ogjg.back.common.util.PathUtil.createNewFilePath;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class FileService {
     private final ContainerRepository containerRepository;
-    private final PathRepository pathRepository;
     private final S3FileService s3FileService;
+    private final PathService pathService;
 
     @Transactional
     public void createFile(Long containerId, String filePath, String uuid) {
         Container findContainer = findContainerById(containerId);
         String email = findContainer.getUser().getEmail();
-        String s3Path = givenPathToS3Path(email, filePath);
 
-        if (s3FileService.isFileAlreadyExist(s3Path)) throw new FileAlreadyExists();
-
-        pathRepository.save(Path.builder()
-                .container(findContainer)
-                .path(extractFilePrefix(filePath))
-                .name(extractFilename(filePath))
-                .uuid(uuid)
-                .build());
-
-        s3FileService.createFile(s3Path);
+        pathService.saveFilePath(findContainer, filePath, uuid);
+        s3FileService.createFileKey(email, filePath);
     }
 
     @Transactional
     public void deleteFile(Long containerId, String filePath) {
         Container findContainer = findContainerById(containerId);
         String email = findContainer.getUser().getEmail();
-        String s3Path = givenPathToS3Path(email, filePath);
 
-        if (!s3FileService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
-
-        // db 삭제
-        Path findPath = findContainer.findPath(
-                extractFilePrefix(filePath),
-                S3PathUtil.extractFilename(filePath)
-        );
-        pathRepository.delete(findPath);
-
-        // s3 삭제
-        s3FileService.deleteFile(s3Path);
+        pathService.deleteFilePath(findContainer, filePath);
+        s3FileService.deleteFile(email, filePath);
     }
 
     @Transactional
     public void updateFile(Long containerId, String filePath, UpdateFileRequest request) {
         Container findContainer = findContainerById(containerId);
         String email = findContainer.getUser().getEmail();
-        String s3Path = givenPathToS3Path(email, filePath);
 
-        if (!isContainerExist(email, extractContainerName(filePath))) throw new NotFoundContainer();
-        if (!s3FileService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
-
-        s3FileService.updateFile(s3Path, request.getContent());
+        s3FileService.updateFile(email, filePath, request.getContent());
     }
 
     @Transactional
     public void updateFilename(Long containerId, String filePath, String newFilename) {
         Container findContainer = findContainerById(containerId);
         String email = findContainer.getUser().getEmail();
-        String s3Path = givenPathToS3Path(email, filePath);
         String newFilePath = createNewFilePath(filePath, newFilename);
 
-//        if (!isContainerExist(loginEmail, containerName)) throw new NotFoundContainer();
-        if (!s3FileService.isFileAlreadyExist(s3Path)) throw new NotFoundFile();
-
-        // db rename
-        Path findPath = findContainer.findPath(
-                extractFilePrefix(filePath),
-                extractFilename(filePath)
-        );
-        findPath.rename(newFilename);
-
-        // s3 rename
-        s3FileService.updateFilename(email, filePath, newFilePath);
-    }
-
-    private boolean isContainerExist(String loginEmail, String containerName) {
-        return containerRepository.findByNameAndEmail(containerName, loginEmail)
-                .isPresent();
-    }
-
-    private Container findContainerByNameAndEmail(String containerName, String loginEmail) {
-        Container container = containerRepository.findByNameAndEmail(containerName, loginEmail)
-                .orElseThrow(NotFoundContainer::new);
-        return container;
+        pathService.updateFilename(findContainer, filePath, newFilename);
+        s3FileService.updateFileKey(email, filePath, newFilePath);
     }
 
     private Container findContainerById(Long containerId) {

--- a/back/src/main/java/com/ogjg/back/path/repository/PathRepository.java
+++ b/back/src/main/java/com/ogjg/back/path/repository/PathRepository.java
@@ -1,4 +1,4 @@
-package com.ogjg.back.file.repository;
+package com.ogjg.back.path.repository;
 
 import com.ogjg.back.file.domain.Path;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/back/src/main/java/com/ogjg/back/path/service/PathService.java
+++ b/back/src/main/java/com/ogjg/back/path/service/PathService.java
@@ -1,0 +1,92 @@
+package com.ogjg.back.path.service;
+
+import com.ogjg.back.container.domain.Container;
+import com.ogjg.back.file.domain.Path;
+import com.ogjg.back.path.repository.PathRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.ogjg.back.common.util.PathUtil.*;
+import static com.ogjg.back.common.util.PathUtil.extractDirectoryName;
+
+@Service
+@RequiredArgsConstructor
+public class PathService {
+
+    private final PathRepository pathRepository;
+
+    @Transactional
+    public void saveFilePath(Container container, String filePath, String uuid) {
+        pathRepository.save(
+                Path.builder()
+                        .container(container)
+                        .path(extractFilePrefix(filePath))
+                        .name(extractFilename(filePath))
+                        .uuid(uuid)
+                        .build()
+        );
+    }
+
+    @Transactional
+    public void deleteFilePath(Container container, String filePath) {
+        Path findPath = container.findPathBy(
+                extractFilePrefix(filePath),
+                extractFilename(filePath)
+        );
+        pathRepository.delete(findPath);
+    }
+
+    @Transactional
+    public void updateFilename(Container container, String filePath, String newFilename) {
+        Path findPath = container.findPathBy(
+                extractFilePrefix(filePath),
+                extractFilename(filePath)
+        );
+        findPath.rename(newFilename);
+    }
+
+    @Transactional
+    public void saveDirectoryPath(Container container, String directoryPath, String uuid) {
+        pathRepository.save(Path.builder()
+                .container(container)
+                .path(extractDirectoryPrefix(directoryPath))
+                .name(extractDirectoryName(directoryPath))
+                .uuid(uuid)
+                .build());
+    }
+
+    @Transactional
+    public void deleteDirectory(Container container, String directoryPath) {
+        Path findPath = container.findPathBy(
+                extractDirectoryPrefix(directoryPath),
+                extractDirectoryName(directoryPath)
+        );
+        pathRepository.delete(findPath);
+
+        pathRepository.findByPathStartsWith(directoryPath).stream()
+                .forEach(pathRepository::delete);
+    }
+
+    @Transactional
+    public void renameDirectory(Container container, String directoryPath, String newDirectoryName) {
+        Path findPath = container.findPathBy(
+                extractDirectoryPrefix(directoryPath),
+                extractDirectoryName(directoryPath)
+        );
+        findPath.rename(newDirectoryName + DELIMITER);
+
+        renameAllPathInDirectory(directoryPath, newDirectoryName);
+    }
+
+    private void renameAllPathInDirectory(String directoryPath, String newDirectoryName) {
+        List<Path> toChangePaths = pathRepository.findByPathStartsWith(directoryPath);
+        String newPrefix = createNewDirectoryPath(directoryPath, newDirectoryName);
+
+        toChangePaths.stream()
+                .map((path) -> path.rename(directoryPath, newPrefix))
+                .toList();
+    }
+}

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3ContainerRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3ContainerRepository.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,21 +53,35 @@ public class S3ContainerRepository {
     }
 
     public List<S3Object> getAllObjectsByPrefix(String prefix) {
-        ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder()
-                .bucket(bucketName)
-                .prefix(prefix)
-                .build();
+        List<S3Object> s3Objects = new ArrayList<>();
+        try {
+            ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder()
+                    .bucket(bucketName)
+                    .prefix(prefix)
+                    .build();
 
-        return s3Client.listObjectsV2(listObjectsV2Request).contents();
+            s3Objects = s3Client.listObjectsV2(listObjectsV2Request).contents();
+        } catch (Exception e) {
+            log.error("error message={}", e.getMessage());
+        }
+
+        return s3Objects;
     }
 
     public String getFileContent(String key) {
-        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
-                .bucket(bucketName)
-                .key(key)
-                .build();
+        String content = "";
+        try {
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
 
-        return s3Client.getObject(getObjectRequest, ResponseTransformer.toBytes()).asUtf8String();
+            content = s3Client.getObject(getObjectRequest, ResponseTransformer.toBytes()).asUtf8String();
+        } catch (Exception e) {
+            log.error("error message={}", e.getMessage());
+        }
+
+        return content;
     }
 
     public void deleteObjectsWithPrefix(String prefix) {

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3FileRepository.java
@@ -22,10 +22,10 @@ public class S3FileRepository {
 
     private final S3Client s3Client;
 
-    public void putFilePath(String s3Path) {
+    public void putFileKey(String S3Key) {
         try {
             // 파일 확장자를 통해 MIME 타입을 가져옴
-            String mimeType = URLConnection.guessContentTypeFromName(s3Path);
+            String mimeType = URLConnection.guessContentTypeFromName(S3Key);
             if (mimeType == null) {
                 mimeType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
             }
@@ -33,7 +33,7 @@ public class S3FileRepository {
             // S3에 파일 업로드
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucketName)
-                    .key(s3Path)
+                    .key(S3Key)
                     .contentType(mimeType)
                     .build();
 
@@ -44,11 +44,11 @@ public class S3FileRepository {
         }
     }
 
-    public void deleteFile(String s3Path) {
+    public void deleteFile(String S3Key) {
         try {
             DeleteObjectRequest request = DeleteObjectRequest.builder()
                     .bucket(bucketName)
-                    .key(s3Path)
+                    .key(S3Key)
                     .build();
 
             s3Client.deleteObject(request);
@@ -57,11 +57,11 @@ public class S3FileRepository {
         }
     }
 
-    public void putFile(String s3Path, String content) {
+    public void putFile(String S3Key, String content) {
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()
                     .bucket(bucketName)
-                    .key(s3Path)
+                    .key(S3Key)
                     .build();
 
             s3Client.putObject(putObjectRequest, RequestBody.fromString(content));
@@ -70,32 +70,32 @@ public class S3FileRepository {
         }
     }
 
-    public void rename(String s3Path, String newS3FilePath) {
-        log.info("nowFilePath={}", s3Path);
-        log.info("newS3FilePath={}", newS3FilePath);
+    public void renameKey(String S3Key, String newS3Key) {
+        log.info("S3Key={}", S3Key);
+        log.info("newS3Key={}", newS3Key);
         try {
             CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder()
                     .sourceBucket(bucketName)
-                    .sourceKey(s3Path)
+                    .sourceKey(S3Key)
                     .destinationBucket(bucketName)
-                    .destinationKey(newS3FilePath)
+                    .destinationKey(newS3Key)
                     .build();
 
             s3Client.copyObject(copyObjectRequest);
 
             // 기존 파일 삭
-            deleteFile(s3Path);
+            deleteFile(S3Key);
 
         } catch (Exception e) {
             log.error("error message={}", e.getMessage());
         }
     }
 
-    public boolean isFileExist(String s3Path) {
+    public boolean isFileExist(String S3Key) {
         try {
             HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
                     .bucket(bucketName)
-                    .key(s3Path)
+                    .key(S3Key)
                     .build();
 
             s3Client.headObject(headObjectRequest);

--- a/back/src/main/java/com/ogjg/back/s3/repository/S3ImageUploadRepository.java
+++ b/back/src/main/java/com/ogjg/back/s3/repository/S3ImageUploadRepository.java
@@ -13,7 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static com.ogjg.back.common.util.S3PathUtil.DELIMITER;
+import static com.ogjg.back.common.util.PathUtil.DELIMITER;
 
 @Slf4j
 @Repository

--- a/back/src/main/java/com/ogjg/back/s3/service/S3ContainerService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3ContainerService.java
@@ -11,8 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
-import static com.ogjg.back.common.util.S3PathUtil.createEmailRemovedKey;
-import static com.ogjg.back.common.util.S3PathUtil.isFile;
+import static com.ogjg.back.common.util.PathUtil.createEmailRemovedKey;
+import static com.ogjg.back.common.util.PathUtil.isFile;
 
 @Slf4j
 @Service
@@ -59,7 +59,6 @@ public class S3ContainerService {
         return fileData;
     }
 
-    // todo: 병렬처리 등 요청수 줄일 방법 고려하기
     private List<ContainerGetFileResponse> createFileResponse(List<String> keys, String email) {
         return keys.stream()
                 .map((key) -> toFileResponse(key, email))
@@ -71,17 +70,6 @@ public class S3ContainerService {
                 .filePath(createEmailRemovedKey(key, email))
                 .content(s3ContainerRepository.getFileContent(key))
                 .build();
-    }
-
-    /**
-     * 컨테이너 모든 구조 가져오기 - 디렉토리 데이터 생성
-     * 이메일 경로를 제외한 구조를 응답값에 포함해야 하므로 절삭된 키 사용
-     */
-    @Transactional(readOnly = true)
-    public List<String> getDirectories(List<String> parsedKeys) {
-        return parsedKeys.stream()
-                .filter((key) -> !isFile(key))
-                .toList();
     }
 
     @Transactional

--- a/back/src/main/java/com/ogjg/back/s3/service/S3DirectoryService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3DirectoryService.java
@@ -1,13 +1,19 @@
 package com.ogjg.back.s3.service;
 
+import com.ogjg.back.directory.exception.DirectoryAlreadyExists;
+import com.ogjg.back.directory.exception.NotFoundDirectory;
 import com.ogjg.back.s3.repository.S3DirectoryRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.model.S3Object;
 
 import java.util.List;
 
+import static com.ogjg.back.common.util.PathUtil.*;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class S3DirectoryService {
@@ -15,24 +21,45 @@ public class S3DirectoryService {
     private final S3DirectoryRepository s3DirectoryRepository;
 
     @Transactional
-    public void createDirectory(String s3Path) {
-        s3DirectoryRepository.putDirectoryPath(s3Path);
+    public void createDirectory(String email, String directoryPath) {
+        String s3Key = pathToS3Key(email, directoryPath);
+
+        if (isDirectoryAlreadyExist(s3Key)) throw new DirectoryAlreadyExists();
+        s3DirectoryRepository.putDirectoryPath(s3Key);
     }
 
     @Transactional(readOnly = true)
-    public boolean isDirectoryAlreadyExist(String s3Path) {
-        return s3DirectoryRepository.isDirectoryExist(s3Path);
+    public boolean isDirectoryAlreadyExist(String s3Key) {
+        return s3DirectoryRepository.isDirectoryExist(s3Key);
     }
 
     @Transactional
-    public void deleteDirectory(String s3Path) {
-        s3DirectoryRepository.deleteObjectsWithPrefix(s3Path);
+    public void deleteDirectory(String email, String directoryPath) {
+        String s3Key = pathToS3Key(email, directoryPath);
+
+        if (!isDirectoryAlreadyExist(s3Key)) throw new NotFoundDirectory();
+
+        s3DirectoryRepository.deleteObjectsWithPrefix(s3Key);
     }
 
     @Transactional
-    public void updateDirectoryName(String originS3Prefix, String newS3Prefix) {
-        List<S3Object> objects = s3DirectoryRepository.getObjectsBy(originS3Prefix);
+    public void updateDirectoryName(String email, String directoryPath, String newDirectoryName) {
+        String originS3Key = pathToS3Key(email, directoryPath);
+        String newS3Key = createNewDirectoryPath(originS3Key, newDirectoryName);
+        if (!isDirectoryAlreadyExist(originS3Key)) throw new NotFoundDirectory();
 
-        s3DirectoryRepository.copyAndPasteObjects(objects, originS3Prefix, newS3Prefix);
+        List<S3Object> objects = s3DirectoryRepository.getObjectsBy(originS3Key);
+        copyAndPasteObjects(objects, originS3Key, newS3Key);
+    }
+
+    private void copyAndPasteObjects(List<S3Object> objects, String originPrefix, String newS3Prefix) {
+        for (S3Object s3Object : objects) {
+            String newKey = createNewKey(s3Object.key(), originPrefix, newS3Prefix);
+
+            log.debug("newKey={}", newKey);
+
+            s3DirectoryRepository.copyObject(s3Object, newKey);
+            s3DirectoryRepository.deleteObject(s3Object);
+        }
     }
 }

--- a/back/src/main/java/com/ogjg/back/s3/service/S3ProfileImageService.java
+++ b/back/src/main/java/com/ogjg/back/s3/service/S3ProfileImageService.java
@@ -8,8 +8,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import static com.ogjg.back.common.util.S3PathUtil.createImagePrefix;
-import static com.ogjg.back.common.util.S3PathUtil.extractExtension;
+import static com.ogjg.back.common.util.PathUtil.createImagePrefix;
+import static com.ogjg.back.common.util.PathUtil.extractExtension;
 
 @Slf4j
 @Service


### PR DESCRIPTION
## 리팩터링 진행
### 책임 분리
- S3로 시작하는 Repository, Service와 그렇지 않은 것을 확실히 구분해서 책임을 분리하려고 했습니다. S3로 시작하는 Repository에는 S3와 데이터를 주고받는 기능, Service에는 관련 s3Repository의 기능을 조합하고 논리적 흐름을 만드는 데 사용했습니다.
- 그렇다보니 Service에서 Service를 사용하는 형태로 코드가 작성되었습니다. s3 관련 로직에서 다른 서비스를 참조하지 않고, 다른 서비스에서  s3 관련 로직을 참조하는 형식으로 사용했습니다.

예시

Before
```java
 @Transactional
    public void createFile(Long containerId, String filePath, String uuid) {
        Container findContainer = findContainerById(containerId);
        String email = findContainer.getUser().getEmail();
        String s3Path = givenPathToS3Path(email, filePath);

        // 파일이 이미 존재하는지 검증하는 내용
        if (s3FileService.isFileAlreadyExist(s3Path)) throw new FileAlreadyExists();

        // path 객체를 생성하는 내용
        pathRepository.save(Path.builder()
                .container(findContainer)
                .path(extractFilePrefix(filePath))
                .name(extractFilename(filePath))
                .uuid(uuid)
                .build());

        s3FileService.createFile(s3Path);
        pathService.saveFilePath(findContainer, filePath, uuid);
    }
```

After
```java

// ide에서 새 파일을 생성하면 호출되는 서비스 메서드
@Transactional
    public void createFile(Long containerId, String filePath, String uuid) {
        Container findContainer = findContainerById(containerId);
        String email = findContainer.getUser().getEmail();

       // db에 파일 경로를 저장한다. -> Path 객체 생성하는 내용 포함
        pathService.saveFilePath(findContainer, filePath, uuid);

       // s3에 해당 파일 경로를 이용해 key를 생성한다. -> isFileAlreadyExist로 검증하는 부분을 포함
       // 변수명 변경. s3에서 사용하는 경로는 key라고 명명
        s3FileService.createFileKey(email, filePath);
    }
```

### 변수명 정리 경로를 key, path, name으로 구분하기

- key 
  - s3에서 사용할 키(경로)
  - prefix로 해당 사용자의 이메일이 포함된다.
  - ‘@', '.’ 문자는 -로 변환해서 경로로 사용한다.
  - ex1) `my-email-naver-com/my-container/hello/bird/`

- path
  - 어플리케이션에서 사용하는 디렉토리/파일의 전체 경로
  - prefix로 해당 사용자의 컨테이너 이름이 포함된다.
  - 디렉토리 경로의 경우 양끝에 구분자 / 가 붙는다.
  - 파일의 경우 맨 마지막에 구분자 / 가 존재하지 않는다.
    - ex1) `/my-container/hello/bird/`
    - ex2) `/my-container/hello/bird/duck.java`

- name
  - 어플리케이션에서 사용하는 이름. 
  - 현재 디렉토리/파일의 이름만을 추출한 부분으로 경로 구분자인 /가 전혀 들어가지 않는다.
  - ex1) container1/bird 에서 `bird`
  - ex2) container1/bird/duck.py 에서 `duck.py`
- prefix
  - 사실상 key와 같다.
  - getS3Objects에서 prefix로 객체 목록을 가져올때, prefix라고 명명한다. key를 인수로 넣고, 파라미터에서는 prefix라고 쓸 생각이다.
  - ex) `container1/bird/duck.py`에서 bird를 changebird로 rename한다면, prefix라는 명칭으로 검색한다. s3에서 key값을, db에서 path의 prefix 값을 찾아서 rename 해야한다.

## 변경사항

### S3PathUtil -> PathUtil
- [x] 클래스 명 PathUtil로 수정
- s3Path(key)를 생성하는 것 뿐 아니라 path 자체를 추출하고 생성하는 기능이 존재해서 PathUtil로 변경했습니다.
- [x] 메서드명, 변수명 수정
- [x] 확장자, image 기본 이름 등 상수로 추출
- [x] 사용하지 않는 메서드 삭제

### FileService
- [x] 중복되는 검증로직, 사용하지 않는 메서드 삭제
- 컨테이너 존재 여부를 컨테이너를 ID로 찾는 기능에서 이미 검증한다.
- 사용하지 않게 된 검증 메서드와 find 메서드를 삭제했다.
- [x] s3 검증로직 s3Service 안으로 캡슐화
- [x] pathService 생성, 관련 로직 캡슐화

### DirectoryService
- [x] 중복되는 검증로직, 사용하지 않는 메서드 삭제
- [x] s3 검증로직 s3Service 안으로 캡슐화
- [x] pathService 관련 로직 캡슐화

### s3 관련Repository
- [x] 누락된 try-catch문 추가
- 반복되는 try-catch문을 제거할 방법을 생각중입니다.