### PR TITLE
Fix : OW-108 FE 메인 페이지 각종 기능 버그 수정

### DIFF
--- a/front/src/api/useContainerAPI.ts
+++ b/front/src/api/useContainerAPI.ts
@@ -8,11 +8,11 @@ export default function useContainerAPI() {
   const axios = useAxios();
 
   //🔥 containerData 요청
-  const requestContainerData = (
+  const requestContainerData = async (
     searchContainer: string,
     setContainers: SetterOrUpdater<T.containerDataType[]>,
   ) => {
-    axios
+    await axios
       .get(`${profileURL}/containers?search=${searchContainer}`)
       .then((response) => {
         setContainers(response.data.data);
@@ -31,7 +31,7 @@ export default function useContainerAPI() {
     await axios
       .put(`${profileURL}/containers/${containerId}/private`, requestData)
       .then((response) => {
-        setPrivated(response.data.data.private);
+        setPrivated(response.data.data.isPrivate);
       })
       .catch((error) => {
         alert(error);
@@ -69,7 +69,6 @@ export default function useContainerAPI() {
       .put(`${profileURL}/containers/${containerId}/pin`, requestData)
       .then((response) => {
         setPinned(response.data.data.pinned);
-        console.log(response.data.data.pinned);
       })
       .catch((error) => {
         alert(error);

--- a/front/src/components/Sidebar/Sidebar.tsx
+++ b/front/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,7 @@
 import * as S from "./Sidebar.style";
 import * as Icon from "../Icon";
 import UserInfo from "./components/UserInfo";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import {
   isMSidebarOpenState,
   isMenuHoverState,
@@ -10,14 +10,17 @@ import {
 import Space from "./components/Space";
 import { Desktop, Mobile } from "../Responsive";
 import { useNavigate } from "react-router";
+import { isUserInfo } from "../../recoil/SidebarState";
 function Sidebar() {
   const navigate = useNavigate();
   const [isSidebarOpen, setIsSidebarOpen] = useRecoilState(isSidebarOpenState);
   const [isMSidebarOpen, setIsMSidebarOpen] = useRecoilState(isMSidebarOpenState);
   const [isMenuHover, setIsMenuHover] = useRecoilState(isMenuHoverState);
+  const setInfoOpen = useSetRecoilState<boolean>(isUserInfo);
   const handleSidebarClose = () => {
     setIsSidebarOpen(false);
     setIsMSidebarOpen(false);
+    setInfoOpen(false);
   };
   const handleHoverMenu = () => {
     setIsMenuHover(true);

--- a/front/src/components/Sidebar/components/UserInfo.tsx
+++ b/front/src/components/Sidebar/components/UserInfo.tsx
@@ -1,15 +1,16 @@
 import * as S from "./UserInfo.style";
 import * as Icon from "../../Icon";
-import { useState } from "react";
+// import { useState } from "react";
 import UserModal from "./UserModal";
-import { useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue } from "recoil";
 import { userInfoState } from "../../../recoil/userState";
+import { isUserInfo } from "../../../recoil/SidebarState";
 
 function UserInfo() {
   const userInfo = useRecoilValue(userInfoState);
-  const [info, setInfo] = useState<boolean>(false);
+  const [infoOpen, setInfoOpen] = useRecoilState<boolean>(isUserInfo);
   const handleUserModal = () => {
-    setInfo((prev) => !prev);
+    setInfoOpen((prev) => !prev);
   };
   return (
     <>
@@ -25,10 +26,10 @@ function UserInfo() {
         </S.UserBox>
 
         <S.DetailBtn>
-          {!info ? <Icon.DownArrow1 size={10} /> : <Icon.RightArrow1 size={10} />}
+          {!infoOpen ? <Icon.DownArrow1 size={10} /> : <Icon.RightArrow1 size={10} />}
         </S.DetailBtn>
       </S.UserInfoBox>
-      {info && <UserModal />}
+      {infoOpen && <UserModal />}
     </>
   );
 }

--- a/front/src/pages/Main/Body/components/BodyContainers.tsx
+++ b/front/src/pages/Main/Body/components/BodyContainers.tsx
@@ -24,9 +24,8 @@ function BodyContainers() {
         const dateB: Date = new Date(b.updatedDate);
         return dateB.getTime() - dateA.getTime();
       } else {
-        const dateA: Date = new Date(a.createdDate);
-        const dateB: Date = new Date(b.createdDate);
-        return dateB.getTime() - dateA.getTime();
+        return a.name.localeCompare(b.name);
+        // 이름순으로 정렬
       }
     }
   });

--- a/front/src/pages/Main/Body/components/BodyHeader.tsx
+++ b/front/src/pages/Main/Body/components/BodyHeader.tsx
@@ -59,7 +59,7 @@ function BodyHeader() {
           <S.RecentIcon>
             <Icon.SortRecent size={16} />
           </S.RecentIcon>
-          <S.RecentDiv>{ordered === "updated" ? "최근 수정순" : "이름순"}</S.RecentDiv>
+          <S.RecentDiv>{ordered === "updated" ? "최근 생성순" : "이름순"}</S.RecentDiv>
           {isRecentUpdateModal && <RecentUpdateModal />}
         </S.RecentBtn>
       </S.BodyHeaderWrapper>

--- a/front/src/pages/Main/Body/components/BodyHeader.tsx
+++ b/front/src/pages/Main/Body/components/BodyHeader.tsx
@@ -1,6 +1,6 @@
 import * as S from "./BodyHeader.style";
 import * as Icon from "../../../../components/Icon";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import {
   isOrdered,
   isUpdateModal,
@@ -16,7 +16,7 @@ function BodyHeader() {
   const [searchText, setSearchText] = useState<string>("");
   const [searchContainer, setSearchContainer] = useRecoilState(isSearchContainer);
   const [containers, setContainers] = useRecoilState(containersState);
-  const [totalContainers, setTotalContainers] = useRecoilState(containersState);
+  const setTotalContainers = useSetRecoilState(containersState);
   const ordered = useRecoilValue(isOrdered);
   const { requestContainerData } = useContainerAPI();
 
@@ -41,7 +41,7 @@ function BodyHeader() {
       requestContainerData(searchContainer, setTotalContainers);
     }
   }, []);
-  console.log(totalContainers);
+
   return (
     <div>
       <S.BodyHeaderWrapper>
@@ -59,9 +59,7 @@ function BodyHeader() {
           <S.RecentIcon>
             <Icon.SortRecent size={16} />
           </S.RecentIcon>
-          <S.RecentDiv>
-            {ordered === "updated" ? "최근 수정순" : "최근 생성순"}
-          </S.RecentDiv>
+          <S.RecentDiv>{ordered === "updated" ? "최근 수정순" : "이름순"}</S.RecentDiv>
           {isRecentUpdateModal && <RecentUpdateModal />}
         </S.RecentBtn>
       </S.BodyHeaderWrapper>

--- a/front/src/pages/Main/Body/components/Container.tsx
+++ b/front/src/pages/Main/Body/components/Container.tsx
@@ -142,7 +142,7 @@ function Container(props: BodyContainerPops) {
                 return (
                   <>
                     <S.UserImgContainer>
-                      <S.UserName>{user.userName}</S.UserName>
+                      <S.UserName>{user.userName.slice(0, 4)}</S.UserName>
                       <S.UserImgDiv>
                         <S.UserImg src={user.imgUrl} />
                       </S.UserImgDiv>

--- a/front/src/pages/Main/Body/components/ContainerSettingModal.tsx
+++ b/front/src/pages/Main/Body/components/ContainerSettingModal.tsx
@@ -41,8 +41,9 @@ function ContainerSettingModal({
     setDeleteModal(true);
   };
   const handleCopyUrl = () => {
+    const API_URL = import.meta.env.VITE_API_URL;
     window.navigator.clipboard
-      .writeText(`http://localhost:5173/container/${containerData.containerId}`)
+      .writeText(`${API_URL}/container/${containerData.containerId}`)
       .then(() => {
         alert("컨테이너 링크가 복사되었습니다.");
         setContainerSettingModal(false);
@@ -52,9 +53,9 @@ function ContainerSettingModal({
     // 🔥 핀 상태값 변경 요청
     try {
       await requestPutContainerPinned(containerData.containerId, setPinned);
+      requestContainerData(searchContainer, setContainers);
       setContainerSettingModal(false);
       setDeleteModal(false);
-      requestContainerData(searchContainer, setContainers);
     } catch (error) {
       alert(error);
     }

--- a/front/src/pages/Main/Body/components/RecentUpdateModal.tsx
+++ b/front/src/pages/Main/Body/components/RecentUpdateModal.tsx
@@ -32,7 +32,7 @@ function RecentUpdateModal() {
             handleRecentBtn();
           }}
         >
-          최근 생성순
+          이름순
           {ordered === "recent" && (
             <S.DotIconDiv>
               <Icon.Dot />

--- a/front/src/pages/Main/Body/components/RecentUpdateModal.tsx
+++ b/front/src/pages/Main/Body/components/RecentUpdateModal.tsx
@@ -19,7 +19,7 @@ function RecentUpdateModal() {
             handleUpdatedBtn();
           }}
         >
-          최근 수정순
+          최근 생성순
           {ordered === "updated" && (
             <S.DotIconDiv>
               <Icon.Dot />

--- a/front/src/recoil/SidebarState.ts
+++ b/front/src/recoil/SidebarState.ts
@@ -4,3 +4,8 @@ export const isSpaceItemId = atom<number>({
   key: "isSpaceItemId",
   default: 1,
 });
+
+export const isUserInfo = atom<boolean>({
+  key: "isUserInfo",
+  default: false,
+});


### PR DESCRIPTION
## [메인 페이지 컨테이너]

### 1. 컨테이너 링크 복사시 localhost로 되어있는 사항 https://ogjg.site로 수정 할 것

### 2. 컨테이너 공개 전환 : 프라이빗 → 퍼블릭 변화시 렌더링 바로 안됨

### 3. 생성순 및 업데이트 순으로 되어있던 정렬 모달 수정

<img width="1166" alt="image" src="https://github.com/Goorm-OGJG/Web-IDE/assets/93318615/1451e685-2fc0-4d3b-ac9c-aa45ca38b231">


	- 업데이트 순을 이름순으로 바꾸었고, 이름순을 클릭하면 이름순으로 정렬된다.

	- 고정된 컨테이너는 고정이 우선이기 때문에 이름순은 고정을 제외하고 반영된다.

### 4. 사이드바 컨테이너 닫으면 UserInfo 모달 닫도록 설정
<img width="626" alt="image" src="https://github.com/Goorm-OGJG/Web-IDE/assets/93318615/ed414371-60ca-4def-9158-dd80614ca088">


### 5. 컨테이너 참여 유저 호버시 유저 이름 3개만 나오도록 변경
<img width="317" alt="image" src="https://github.com/Goorm-OGJG/Web-IDE/assets/93318615/b7eebf66-92eb-4ecf-9533-232568964d0d">
