### PR TITLE
Fix : OW-122 컨테이너에 공개여부가 설정되지 않는 버그 수정

### DIFF
--- a/back/src/main/java/com/ogjg/back/container/controller/ContainerController.java
+++ b/back/src/main/java/com/ogjg/back/container/controller/ContainerController.java
@@ -6,7 +6,9 @@ import com.ogjg.back.config.security.jwt.JwtUserDetails;
 import com.ogjg.back.container.dto.request.ContainerCreateRequest;
 import com.ogjg.back.container.dto.response.ContainerCheckNameResponse;
 import com.ogjg.back.container.dto.response.ContainerGetResponse;
+import com.ogjg.back.container.dto.response.ContainerResponse;
 import com.ogjg.back.container.service.ContainerService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -22,12 +24,14 @@ public class ContainerController {
      * 컨테이너 생성
      */
     @PostMapping("")
-    public ApiResponse<Void> create(
-            @RequestBody ContainerCreateRequest request,
+    public ApiResponse<ContainerResponse> create(
+            @Valid @RequestBody ContainerCreateRequest request,
             @AuthenticationPrincipal JwtUserDetails user
     ) {
-        containerService.createContainer(user.getEmail(), request);
-        return new ApiResponse<>(ErrorCode.SUCCESS);
+        return new ApiResponse<>(
+                ErrorCode.SUCCESS,
+                containerService.createContainer(user.getEmail(), request)
+        );
     }
 
     /**

--- a/back/src/main/java/com/ogjg/back/container/dto/request/ContainerCreateRequest.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/request/ContainerCreateRequest.java
@@ -1,5 +1,6 @@
 package com.ogjg.back.container.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ogjg.back.container.domain.Container;
 import com.ogjg.back.user.domain.User;
 import jakarta.validation.constraints.Pattern;
@@ -19,6 +20,7 @@ public class ContainerCreateRequest {
             message = "컨테이너 이름에는 영문, 숫자가 포함가능하며, 특수문자는 '-', '_'만 포함될 수 있습니다.")
     private String name;
     private String description;
+    @JsonProperty("private")
     private boolean isPrivate;
     private String language;
 

--- a/back/src/main/java/com/ogjg/back/container/dto/response/ContainerResponse.java
+++ b/back/src/main/java/com/ogjg/back/container/dto/response/ContainerResponse.java
@@ -1,0 +1,55 @@
+package com.ogjg.back.container.dto.response;
+
+import com.ogjg.back.container.domain.Container;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class ContainerResponse {
+    private Long containerId;
+    private String email;
+    private String containerName;
+    private String description;
+    private String language;
+    private String containerUrl;
+    private Boolean isPrivate;
+    private Long availableStorage;
+    private Boolean isPinned;
+    private LocalDateTime modifiedAt;
+    private LocalDateTime createdAt;
+
+    public ContainerResponse(Container container) {
+        this.containerId = container.getContainerId();
+        this.email = container.getUser().getEmail();
+        this.containerName = container.getName();
+        this.description = container.getDescription();
+        this.language = container.getLanguage();
+        this.containerUrl = container.getContainerUrl();
+        this.isPrivate = container.getIsPrivate();
+        this.availableStorage = container.getAvailableStorage();
+        this.isPinned = container.getIsPinned();
+        this.modifiedAt = container.getModifiedAt();
+        this.createdAt = container.getCreatedAt();
+    }
+
+    @Builder
+    public ContainerResponse(Long containerId, String containerName, String email, String description, String language, String containerUrl, Boolean isPrivate, Long availableStorage, Boolean isPinned, LocalDateTime modifiedAt, LocalDateTime createdAt) {
+        this.containerId = containerId;
+        this.containerName = containerName;
+        this.email = email;
+        this.description = description;
+        this.language = language;
+        this.containerUrl = containerUrl;
+        this.isPrivate = isPrivate;
+        this.availableStorage = availableStorage;
+        this.isPinned = isPinned;
+        this.modifiedAt = modifiedAt;
+        this.createdAt = createdAt;
+    }
+}

--- a/back/src/main/java/com/ogjg/back/directory/repository/DirectoryRepository.java
+++ b/back/src/main/java/com/ogjg/back/directory/repository/DirectoryRepository.java
@@ -1,7 +1,0 @@
-package com.ogjg.back.directory.repository;
-
-import com.ogjg.back.file.domain.Path;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface DirectoryRepository extends JpaRepository<Path, String> {
-}

--- a/back/src/main/java/com/ogjg/back/path/service/PathService.java
+++ b/back/src/main/java/com/ogjg/back/path/service/PathService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.ogjg.back.common.util.PathUtil.*;
 import static com.ogjg.back.common.util.PathUtil.extractDirectoryName;
@@ -88,5 +89,9 @@ public class PathService {
         toChangePaths.stream()
                 .map((path) -> path.rename(directoryPath, newPrefix))
                 .toList();
+    }
+
+    public Optional<String> findUuid(Long containerId, String filePrefix, String filename) {
+        return pathRepository.findUuid(containerId, filePrefix, filename);
     }
 }

--- a/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
+++ b/back/src/test/java/com/ogjg/back/container/controller/ContainerControllerTest.java
@@ -3,21 +3,20 @@ package com.ogjg.back.container.controller;
 import com.ogjg.back.common.ControllerTest;
 import com.ogjg.back.container.dto.request.ContainerCreateRequest;
 import com.ogjg.back.container.dto.request.ContainerGetDirectoryResponse;
-import com.ogjg.back.container.dto.response.ContainerGetFileResponse;
-import com.ogjg.back.container.dto.response.ContainerCheckNameResponse;
-import com.ogjg.back.container.dto.response.ContainerGetNodeResponse;
-import com.ogjg.back.container.dto.response.ContainerGetResponse;
+import com.ogjg.back.container.dto.response.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.BDDMockito.*;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
@@ -30,22 +29,33 @@ public class ContainerControllerTest extends ControllerTest {
     public void create() throws Exception {
         //given
         ContainerCreateRequest request = ContainerCreateRequest.builder()
-                .name("이회장")
+                .name("my-container")
                 .description("자바 연습 할거야")
                 .isPrivate(false)
                 .language("Java")
                 .build();
 
-        doNothing()
-                .when(containerService)
-                .createContainer(anyString(), eq(request));
+        ContainerResponse response = ContainerResponse.builder()
+                .containerId(1L)
+                .email("ogjg1234@naver.com")
+                .containerName("my-container")
+                .description("자바 연습 할거야")
+                .language("Java")
+                .containerUrl("url")
+                .isPrivate(false)
+                .availableStorage(10L)
+                .isPinned(false)
+                .modifiedAt(LocalDateTime.now())
+                .createdAt(LocalDateTime.now()).build();
+
+        given(containerService.createContainer(anyString(), any(ContainerCreateRequest.class)))
+                .willReturn(response);
 
         // when
         ResultActions result = this.mockMvc.perform(
                 post("/api/containers")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .accept(MediaType.APPLICATION_JSON)
         );
 
         // then
@@ -57,6 +67,22 @@ public class ContainerControllerTest extends ControllerTest {
                         fieldWithPath("description").description("컨테이너 설명").optional(),
                         fieldWithPath("private").description("비공개 여부"),
                         fieldWithPath("language").description("프로그래밍 언어")
+                ),
+                responseFields(
+                        fieldWithPath("status.code").description("응답 코드"),
+                        fieldWithPath("status.message").description("응답 메시지"),
+
+                        fieldWithPath("data.containerId").description("컨테이너 ID"),
+                        fieldWithPath("data.email").description("컨테이너 생성한 회원의 이메일"),
+                        fieldWithPath("data.containerName").description("컨테이너 이름"),
+                        fieldWithPath("data.description").description("컨테이너 설명"),
+                        fieldWithPath("data.language").description("컨테이너 언어"),
+                        fieldWithPath("data.containerUrl").description("컨테이너 url"),
+                        fieldWithPath("data.isPrivate").description("컨테이너 공개 여부"),
+                        fieldWithPath("data.availableStorage").description("사용 가능 용량"),
+                        fieldWithPath("data.isPinned").description("고정 여부"),
+                        fieldWithPath("data.modifiedAt").description("수정 일시"),
+                        fieldWithPath("data.createdAt").description("생성 일시")
                 )
         )).andExpect(status().isOk());
      }


### PR DESCRIPTION
공개, 비공개 여부를 설정해도 항상 같은 값으로 지정되는 버그를 수정했다.
- json 데이터가 넘어올때 private 변수명으로 넘어오는 데이터를 request 객체의 isPrivate 필드에 바인딩하지 못하는 버그 발생
- private 예약어는 이미 존재하기 때문에 명시적으로 `@JsonProperty("private")`를 사용해서 지정해줬다.
- [x] 공개 여부가 설정되지 않는 버그 수정
- @JsonProperty("private") 추가하여 변수명 통일 
- 컨테이너 생성 응답값 추가 및 테스트 수정
- [x] 누락된 내용 추가
- [x] 컨테이너 @Valid 추가
- [x] DirectoryRepository 제거
  - 리팩터링 후 사용하지 않는 DirectoryRepository 제거
  - 관련 테스트 수정