### PR TITLE
Fix : OW-129 코드 에디터 자동완성 단축키 키맵 변경

### DIFF
--- a/front/src/pages/EditContainer/components/CodeEditor/CodeMirror.tsx
+++ b/front/src/pages/EditContainer/components/CodeEditor/CodeMirror.tsx
@@ -131,10 +131,7 @@ function CodeMirror() {
             vscodeDark,
             ...(langExtension ? [langExtension] : []),
             autocompletion(),
-            keymap.of([
-              { key: isMac ? "Cmd-Space" : "Ctrl-Space", run: startCompletion },
-              ...searchKeymap,
-            ]),
+            keymap.of([{ key: "Shift-Space", run: startCompletion }, ...searchKeymap]),
             // EditorState.transactionFilter.of((transaction) => {
             //   if (transaction.docChanged) {
             //     handleCode(transaction);


### PR DESCRIPTION
맥 기존 키맵인 CMD+SPACE 를 하면 Spotlight 가 나오는 버그로
Shift+SPACE 로 변경