### PR TITLE
Fix : OW-130  에디터 뒤로가기 후 새 컨테이너 접속시 탭 상태 남아있는 버그 해결

### DIFF
--- a/front/src/pages/EditContainer/components/CodeEditor/CodeEditor.tsx
+++ b/front/src/pages/EditContainer/components/CodeEditor/CodeEditor.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { useRecoilValue } from "recoil";
+import React, { useEffect } from "react";
+import { useRecoilState } from "recoil";
 import { tabsState } from "../../../../recoil/CodeEditorState";
 import * as S from "./CodeEditor.style";
 import { Desktop, Mobile } from "../../../../components/Responsive";
@@ -11,7 +11,7 @@ import CodeMirror from "./CodeMirror";
 import VoiceChat from "../../../../components/VoiceChat/VoiceChat";
 
 function CodeEditer() {
-  const tabs = useRecoilValue(tabsState);
+  const [tabs, setTabs] = useRecoilState(tabsState);
   const { saveActiveTabFile } = useFileManage();
 
   const handleSave = () => {
@@ -23,6 +23,15 @@ function CodeEditer() {
 
     navigator.clipboard.writeText(webAddress);
   };
+
+  useEffect(() => {
+    const tabsDefulteValue = {
+      active: -1,
+      files: [],
+      codes: [],
+    };
+    setTabs(tabsDefulteValue);
+  }, []);
 
   return (
     <React.Fragment>


### PR DESCRIPTION
useEffect를 사용해서 코드 편집 페이지에 접속할 때마다
tabsState가 매번 기본값을 가지도록 기능 추가