### PR TITLE
Feat : OW-132 EmailHistory 엔티티 추가 이메일에 발송에 대한 내역 저장, 회원 탈퇴여부 검증로직 추가

### DIFF
--- a/back/src/main/java/com/ogjg/back/common/exception/ErrorResult.java
+++ b/back/src/main/java/com/ogjg/back/common/exception/ErrorResult.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-class ErrorResult implements ErrorType {
+public class ErrorResult implements ErrorType {
 
     private final HttpStatus statusCode;
     private final String code;

--- a/back/src/main/java/com/ogjg/back/config/security/config/JwtTokenConfig.java
+++ b/back/src/main/java/com/ogjg/back/config/security/config/JwtTokenConfig.java
@@ -6,6 +6,8 @@ import com.ogjg.back.user.dto.request.JwtUserClaimsDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.context.annotation.RequestScope;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -32,6 +34,11 @@ public class JwtTokenConfig {
     @Bean
     public Map<String, SseEmitter> clients() {
         return new ConcurrentHashMap<>();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
 }

--- a/back/src/main/java/com/ogjg/back/config/security/config/SecurityConfig.java
+++ b/back/src/main/java/com/ogjg/back/config/security/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.ogjg.back.config.security.jwt.accesstoken.AccessAuthenticationProvide
 import com.ogjg.back.config.security.jwt.refreshtoken.RefreshAuthenticationProvider;
 import com.ogjg.back.config.security.jwt.refreshtoken.RefreshTokenAuthenticationFilter;
 import com.ogjg.back.user.service.EmailAuthService;
+import com.ogjg.back.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,8 +16,6 @@ import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -38,9 +37,9 @@ import static org.springframework.security.config.Customizer.withDefaults;
 public class SecurityConfig {
 
     private final EmailAuthService emailAuthService;
+    private final UserService userService;
     private final AuthenticationEntryPoint authenticationEntryPoint;
     private final JwtUtils jwtUtils;
-
 
     private final List<String> permitUrlList = new ArrayList<>(
             List.of(
@@ -103,12 +102,20 @@ public class SecurityConfig {
 
     @Bean
     public AccessAuthenticationFilter accessAuthenticationFilter() throws Exception {
-        return new AccessAuthenticationFilter(new ProviderManager(Collections.singletonList(accessAuthenticationProvider())), authenticationEntryPoint, permitUrlList);
+        return new AccessAuthenticationFilter(
+                new ProviderManager(Collections.singletonList(accessAuthenticationProvider()))
+                , authenticationEntryPoint
+                , userService
+                , permitUrlList);
     }
 
     @Bean
     public RefreshTokenAuthenticationFilter refreshTokenAuthenticationFilter() throws Exception {
-        return new RefreshTokenAuthenticationFilter(new ProviderManager(Collections.singletonList(refreshAuthenticationProvider())), authenticationEntryPoint, jwtUtils);
+        return new RefreshTokenAuthenticationFilter(
+                new ProviderManager(Collections.singletonList(refreshAuthenticationProvider()))
+                , userService
+                , authenticationEntryPoint
+                , jwtUtils);
     }
 
     @Bean
@@ -124,11 +131,6 @@ public class SecurityConfig {
     @Bean
     public EmailAuthenticationProvider emailAuthenticationProvider() {
         return new EmailAuthenticationProvider(jwtUtils);
-    }
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
     }
 
 }

--- a/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthenticationFilter.java
+++ b/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthenticationFilter.java
@@ -34,7 +34,6 @@ public class EmailAuthenticationFilter extends OncePerRequestFilter {
         String uri = request.getRequestURI();
 
         if (uri.startsWith("/favicon")) {
-//            todo favicon 어떻게 처리할지 고민해보기
             return;
         }
 
@@ -53,7 +52,7 @@ public class EmailAuthenticationFilter extends OncePerRequestFilter {
 
         } catch (Exception e) {
             log.error("이메일 인증도중 에러발생 = {}", e.getMessage());
-            authenticationEntryPoint.commence(request, response, new EmailAuthTokenException());
+            authenticationEntryPoint.commence(request, response, new EmailAuthTokenException("이메일 인증 토큰 인증 실패"));
             return;
         }
 

--- a/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthenticationProvider.java
+++ b/back/src/main/java/com/ogjg/back/config/security/emailauth/EmailAuthenticationProvider.java
@@ -23,7 +23,7 @@ public class EmailAuthenticationProvider implements AuthenticationProvider {
         String jwt = String.valueOf(authentication.getCredentials());
 
         if (!jwtUtils.isValidToken(jwt)) {
-            throw new EmailAuthTokenException();
+            throw new EmailAuthTokenException("이메일 인증 토큰 인증 실패");
         }
 
         EmailAuthUserDetails emailAuthUserDetails = emailAuthUserDetails(jwt);

--- a/back/src/main/java/com/ogjg/back/config/security/exception/AccessTokenException.java
+++ b/back/src/main/java/com/ogjg/back/config/security/exception/AccessTokenException.java
@@ -5,7 +5,11 @@ import com.ogjg.back.common.exception.ErrorCode;
 public class AccessTokenException extends CustomTokenException {
 
     public AccessTokenException() {
-        super(ErrorCode.AUTH_FAIL.changeMessage("AccessToken 인증 오류"));
+        super(ErrorCode.AUTH_FAIL);
+    }
+
+    public AccessTokenException(String message) {
+        super(ErrorCode.AUTH_FAIL, message);
     }
 
 }

--- a/back/src/main/java/com/ogjg/back/config/security/exception/CustomTokenException.java
+++ b/back/src/main/java/com/ogjg/back/config/security/exception/CustomTokenException.java
@@ -1,5 +1,6 @@
 package com.ogjg.back.config.security.exception;
 
+import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.common.exception.ErrorData;
 import com.ogjg.back.common.exception.ErrorType;
 import lombok.Getter;
@@ -12,12 +13,17 @@ public abstract class CustomTokenException extends AuthenticationException {
     private ErrorData errorData;
 
 
-    public CustomTokenException(ErrorType errorType) {
+    public CustomTokenException(ErrorCode errorType) {
         super(errorType.getMessage());
         this.errorType = errorType;
     }
 
-    public CustomTokenException(ErrorType errorType, ErrorData errorData) {
+    public CustomTokenException(ErrorCode errorCode, String message) {
+        super(errorCode.changeMessage(message).getMessage());
+        this.errorType = errorCode.changeMessage(message);
+    }
+
+    public CustomTokenException(ErrorCode errorType, ErrorData errorData) {
         super(errorType.getMessage());
         this.errorType = errorType;
         this.errorData = errorData;

--- a/back/src/main/java/com/ogjg/back/config/security/exception/EmailAuthTokenException.java
+++ b/back/src/main/java/com/ogjg/back/config/security/exception/EmailAuthTokenException.java
@@ -1,16 +1,15 @@
 package com.ogjg.back.config.security.exception;
 
 import com.ogjg.back.common.exception.ErrorCode;
-import com.ogjg.back.common.exception.ErrorData;
-import com.ogjg.back.common.exception.ErrorType;
 
 public class EmailAuthTokenException extends CustomTokenException {
 
     public EmailAuthTokenException() {
-        super(ErrorCode.AUTH_FAIL.changeMessage("이메일 인증 토큰 인증 실패"));
+        super(ErrorCode.AUTH_FAIL);
     }
 
-    public EmailAuthTokenException(ErrorType errorType, ErrorData errorData) {
-        super(errorType, errorData);
+    public EmailAuthTokenException(String message) {
+        super(ErrorCode.AUTH_FAIL, message);
     }
+
 }

--- a/back/src/main/java/com/ogjg/back/config/security/exception/RefreshTokenException.java
+++ b/back/src/main/java/com/ogjg/back/config/security/exception/RefreshTokenException.java
@@ -5,7 +5,11 @@ import com.ogjg.back.common.exception.ErrorCode;
 public class RefreshTokenException extends CustomTokenException {
 
     public RefreshTokenException() {
-        super(ErrorCode.AUTH_FAIL.changeMessage("RefreshToken 인증 오류"));
+        super(ErrorCode.AUTH_FAIL);
+    }
+
+    public RefreshTokenException(String message) {
+        super(ErrorCode.AUTH_FAIL, message);
     }
 
 }

--- a/back/src/main/java/com/ogjg/back/config/security/jwt/JwtUtils.java
+++ b/back/src/main/java/com/ogjg/back/config/security/jwt/JwtUtils.java
@@ -1,6 +1,5 @@
 package com.ogjg.back.config.security.jwt;
 
-import com.ogjg.back.common.exception.ErrorCode;
 import com.ogjg.back.config.security.exception.JwtAuthFailure;
 import io.jsonwebtoken.*;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -17,7 +16,7 @@ import java.util.Map;
 @Component
 public class JwtUtils {
 
-    private final static long ACCESS_TOKEN_VALID_TIME = 100 * 5 * 60 * 1000;
+    private final static long ACCESS_TOKEN_VALID_TIME = 5 * 60 * 1000;
     private final static long REFRESH_TOKEN_VALID_TIME = 14 * 24 * 60 * 60 * 1000;
     private final static long EMAIL_TOKEN_VALID_TIME = 3 * 60 * 1000;
     private final static String ISSUER = "team_ogjg_Web_IDE";

--- a/back/src/main/java/com/ogjg/back/config/security/jwt/refreshtoken/RefreshAuthenticationProvider.java
+++ b/back/src/main/java/com/ogjg/back/config/security/jwt/refreshtoken/RefreshAuthenticationProvider.java
@@ -23,7 +23,7 @@ public class RefreshAuthenticationProvider implements AuthenticationProvider {
         String refreshToken = (String) authentication.getCredentials();
 
         if (!jwtUtils.isValidToken(refreshToken)) {
-            throw new RefreshTokenException();
+            throw new RefreshTokenException("RefreshToken 인증 오류");
         }
 
         Claims claims = jwtUtils.getClaims(refreshToken);

--- a/back/src/main/java/com/ogjg/back/user/controller/UserController.java
+++ b/back/src/main/java/com/ogjg/back/user/controller/UserController.java
@@ -136,6 +136,7 @@ public class UserController {
 
         clients.put(clientId, emitter);
         emailAuthService.emailAuth(email, clientId);
+
         ApiResponse<?> apiResponse = new ApiResponse<>(
                 ErrorCode.SUCCESS
                         .changeMessage("email-sending")

--- a/back/src/main/java/com/ogjg/back/user/domain/EmailHistory.java
+++ b/back/src/main/java/com/ogjg/back/user/domain/EmailHistory.java
@@ -1,0 +1,35 @@
+package com.ogjg.back.user.domain;
+
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+public class EmailHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    private final LocalDateTime emailSendAt = LocalDateTime.now();
+
+    @Enumerated(EnumType.STRING)
+    private EmailStatus emailStatus;
+
+    @Enumerated(EnumType.STRING)
+    private EmailMessage emailMessage;
+
+    public EmailHistory(String email, EmailStatus emailStatus, EmailMessage emailMessage) {
+        this.email = email;
+        this.emailStatus = emailStatus;
+        this.emailMessage = emailMessage;
+    }
+}
+
+

--- a/back/src/main/java/com/ogjg/back/user/domain/EmailMessage.java
+++ b/back/src/main/java/com/ogjg/back/user/domain/EmailMessage.java
@@ -1,0 +1,7 @@
+package com.ogjg.back.user.domain;
+
+public enum EmailMessage {
+
+    EMAIL_AUTH, EMAIL_PASSWORD
+
+}

--- a/back/src/main/java/com/ogjg/back/user/domain/EmailStatus.java
+++ b/back/src/main/java/com/ogjg/back/user/domain/EmailStatus.java
@@ -1,0 +1,5 @@
+package com.ogjg.back.user.domain;
+
+public enum EmailStatus {
+    SUCCESS, FAIL
+}

--- a/back/src/main/java/com/ogjg/back/user/repository/EmailHistoryRepository.java
+++ b/back/src/main/java/com/ogjg/back/user/repository/EmailHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.ogjg.back.user.repository;
+
+import com.ogjg.back.user.domain.EmailHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailHistoryRepository extends JpaRepository<EmailHistory, Long> {
+}


### PR DESCRIPTION
- 이메일 전송 성공 실패를 저장하는 history entity 생성
- 로그인, 회원가입, 토큰인증시 사용자가 탈퇴한 유저인지 확인하는 로직 추가
- 이메일을 보내거나할때는 Transactional을 걸면 안 되기 때문에 email을 보내는 로직에 transactional를 삭제
- 이메일 로직에 락이 걸려서 위험하다 ==> transactional을 걸면 DB마다 다르긴 하지만 레코드 별로 락이 걸릴 수 있다
- DB상 에서만 락을 잡고 해당 커밋이 풀리면 문제가 없는데 이메일을 보내는 로직까지 잡고있다보면 구글 이메일 서버가 다운이되면 해당 response를 계속 기달리다보니까
- 서버에서는 불필요한 해당락까지 같이 잡고있기 때문에 문제가 된다 ==> 외부상태에 의존하게되어서 위험하다
- 순환참조로 인한 PasswordEncoder 의존성 위치 변경