### PR TITLE
Fix : OW-136 없는 컨테이너 아이디로 접속 시 코드 편집 페이지 사용가능한 버그

### DIFF
--- a/front/src/api/useFilesAPI.ts
+++ b/front/src/api/useFilesAPI.ts
@@ -2,12 +2,12 @@ import { useAxios } from "./useAxios";
 import * as T from "../types/filesAPIType";
 import { InfoType } from "../types/FileTree";
 import { useFileManage } from "../hooks/CodeEditor/useFileManage";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 export function useFilesAPI() {
   const axios = useAxios();
   const { containerId } = useParams();
-
+  const navigate = useNavigate();
   const {
     setFilesData,
     createFile,
@@ -26,8 +26,9 @@ export function useFilesAPI() {
       .then((response) => {
         setFilesData(response.data.data);
       })
-      .catch((error) => {
-        console.log(error);
+      .catch(() => {
+        alert("존재하지 않는 컨테이너 입니다.");
+        navigate("/main");
       });
   };
 


### PR DESCRIPTION
없는 컨테이너 아이디로 접속 시
"존재하지 않는 컨테이너 입니다." 라는 알림창 렌더링 후
확인 버튼을 누르면 메인 페이지로 리다이렉트 되도록 수정

![image](https://github.com/Goorm-OGJG/Web-IDE/assets/79975172/2e71406e-1cca-460e-91fe-590df338acaf)
