### PR TITLE
Fix : OW-143 채팅목록 가져오기 에러 수정

### DIFF
--- a/back/src/main/java/com/ogjg/back/chat/repository/MessageRepository.java
+++ b/back/src/main/java/com/ogjg/back/chat/repository/MessageRepository.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
+    Optional<List<Message>> findByRoom_Container_ContainerId(Long containerId);
 
     Optional<List<Message>> findAllByRoom(Room room);
 }

--- a/back/src/main/java/com/ogjg/back/chat/repository/RoomRepository.java
+++ b/back/src/main/java/com/ogjg/back/chat/repository/RoomRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
+    boolean existsByContainer_ContainerId(Long containerId);
 
     Optional<Room> findByContainerContainerId(Long containerId);
 }


### PR DESCRIPTION
- [x] 채팅방의 id 값을 기준으로 목록을 불러와 발생하는 에러 해결
    - `room_id` 값에서 `room` 엔티티의 `container_containerId`를 기준으로 채팅 목록을 불러오도록 변경
- [x] 컨테이너 접근 시점에 채팅방 테이블이 존재하지 않는 경우, 채팅방 테이블을 생성하도록 `ensureChatRoomExists()` 메서드를 정의