### PR TITLE
Fix : 채팅 목록 조회 시 발생 에러 수정

### DIFF
--- a/back/src/main/java/com/ogjg/back/chat/service/MessageService.java
+++ b/back/src/main/java/com/ogjg/back/chat/service/MessageService.java
@@ -142,17 +142,12 @@ public class MessageService {
         return users;
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public List<MessageDto> getMessagesInChattingRoom(Long containerId) {
 
-        if (!roomRepository.existsByContainer_ContainerId(containerId)) {
-            throw new NotFoundContainer();
-        }
+        ensureChatRoomExists(containerId);
 
         Optional<List<Message>> messages = messageRepository.findByRoom_Container_ContainerId(containerId);
-        if (messages.isEmpty()) {
-            return new ArrayList<>();
-        }
 
         return messages.orElseGet(ArrayList::new)
                 .stream()


### PR DESCRIPTION
### 문제
- 최초 채팅 목록 조회 시 채팅방이 생성되지 않아 DB에서 조회해오지 못해 에러가 발생.
### 해결
- 기존에 존재하는 `ensureChatRoomExists()` 메서드를 추가해 최초 접근에도 채팅방이 존재하도록 보장
- `ensureChatRoomExists()`는 채팅방이 존재하는지 확인하고, 존재하지 않는다면 채팅방을 생성합니다.